### PR TITLE
Rewrite SeqGenElm.java

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/SeqGenElm.java
+++ b/src/com/lushprojects/circuitjs1/client/SeqGenElm.java
@@ -105,6 +105,9 @@ class SeqGenElm extends ChipElm {
 		if (hasReset())
 			pins[2] = new Pin(1, SIDE_W, "R");
 	}
+	double getVoltageDiff() {
+		return volts[1];
+	}
 	int getPostCount() { return hasReset() ? 3 : 2; }
 	int getVoltageSourceCount() { return 1; }
 	boolean hasOneShot() { return (flags & FLAG_ONE_SHOT) != 0; }

--- a/src/com/lushprojects/circuitjs1/client/SeqGenElm.java
+++ b/src/com/lushprojects/circuitjs1/client/SeqGenElm.java
@@ -27,7 +27,7 @@ class SeqGenElm extends ChipElm {
 	
 	public SeqGenElm(int xx, int yy) {
 		super(xx, yy);
-		flags |= FLAG_HAS_RESET;
+		//flags |= FLAG_HAS_RESET; // Uncomment this if somebody asks for a RESET pin on the SeqGen
 		setupPins();
 		allocNodes();
 	}

--- a/src/com/lushprojects/circuitjs1/client/SeqGenElm.java
+++ b/src/com/lushprojects/circuitjs1/client/SeqGenElm.java
@@ -21,7 +21,6 @@ package com.lushprojects.circuitjs1.client;
 
 import java.util.NoSuchElementException;
 import com.google.gwt.user.client.ui.TextArea;
-import com.google.gwt.user.client.ui.TextBox;
 
 // contributed by Edward Calver
 

--- a/src/com/lushprojects/circuitjs1/client/SeqGenElm.java
+++ b/src/com/lushprojects/circuitjs1/client/SeqGenElm.java
@@ -33,9 +33,9 @@ class SeqGenElm extends ChipElm {
 	}
 	public SeqGenElm(int xa, int ya, int xb, int yb, int f, StringTokenizer st) {
 		super(xa, ya, xb, yb, f, st);
-		data = (short)(new Integer(st.nextToken()).intValue());
+		data = (short)Integer.parseInt(st.nextToken());
 		if (st.hasMoreTokens()) {
-			if (new Boolean(st.nextToken()).booleanValue()) { //Backwards compatibility
+			if (Boolean.parseBoolean(st.nextToken())) { //Backwards compatibility
 				flags |= FLAG_ONE_SHOT;
 				setupPins();
 				allocNodes();

--- a/src/com/lushprojects/circuitjs1/client/SeqGenElm.java
+++ b/src/com/lushprojects/circuitjs1/client/SeqGenElm.java
@@ -81,6 +81,9 @@ class SeqGenElm extends ChipElm {
 		// Ensure bitCount does not exceed the amount of data we have. (This can happen if there was an error)
 		if (bitCount > data.length * Byte.SIZE)
 			bitCount = data.length * Byte.SIZE;
+		
+		if (hasOneShot())
+			bitPosition = data.length * Byte.SIZE; //Set the pos to the end so that this seqgen's one-shot mode doesn't trigger immediately
 	}
 	
 	String getChipName() { return "sequence generator"; }
@@ -189,7 +192,7 @@ class SeqGenElm extends ChipElm {
 			if (ei.checkbox.getState() != ((flags & FLAG_ONE_SHOT) != 0)) { //value changed
 				flags = ei.changeFlag(flags, FLAG_ONE_SHOT);
 				if (hasOneShot())
-					bitPosition = data.length * Byte.SIZE; //Set the pos to the end so that this seqgen's one-shot mode doesn't trigger immediately
+					bitPosition = data.length * Byte.SIZE; //Ditto
 			}
 			return;
 		}
@@ -218,7 +221,7 @@ class SeqGenElm extends ChipElm {
 			}
 			
 			if (hasOneShot() && wasEmpty)
-				bitPosition = data.length * Byte.SIZE; //Set the pos to the end so that this seqgen's one-shot mode doesn't trigger immediately
+				bitPosition = data.length * Byte.SIZE; //Ditto
 			
 			return;
 		}

--- a/src/com/lushprojects/circuitjs1/client/SeqGenElm.java
+++ b/src/com/lushprojects/circuitjs1/client/SeqGenElm.java
@@ -21,196 +21,133 @@ package com.lushprojects.circuitjs1.client;
 
 // contributed by Edward Calver
 
-    class SeqGenElm extends ChipElm {
-	boolean hasReset() {return false;}
-	public SeqGenElm(int xx, int yy) { super(xx, yy); }
-	public SeqGenElm(int xa, int ya, int xb, int yb, int f,
-			    StringTokenizer st) {
-	    super(xa, ya, xb, yb, f, st);
-	data = (short)(new Integer(st.nextToken()).intValue());
-	if(st.hasMoreTokens()){oneshot=new Boolean(st.nextToken()).booleanValue();position=8;}
+class SeqGenElm extends ChipElm {
+	final int FLAG_HAS_RESET = 2; //Flag for backwards compatibility
+	final int FLAG_ONE_SHOT = 4;
+	
+	public SeqGenElm(int xx, int yy) {
+		super(xx, yy);
+		flags |= FLAG_HAS_RESET;
+		setupPins();
+		allocNodes();
 	}
-	short data=0;
-byte position=0;
-boolean oneshot=false;
-double lastchangetime=0;
-	boolean clockstate=false;
-	String getChipName() { return "Sequence generator"; }
+	public SeqGenElm(int xa, int ya, int xb, int yb, int f, StringTokenizer st) {
+		super(xa, ya, xb, yb, f, st);
+		data = (short)(new Integer(st.nextToken()).intValue());
+		if (st.hasMoreTokens()) {
+			if (new Boolean(st.nextToken()).booleanValue()) { //Backwards compatibility
+				flags |= FLAG_ONE_SHOT;
+				setupPins();
+				allocNodes();
+			}
+			position = 8;
+		}
+	}
+	
+	short data = 0;
+	byte position = 0;
+	double lastchangetime = 0;
+	boolean clockstate = false;
+	String getChipName() { return "sequence generator"; }
 	void setupPins() {
-	    sizeX = 2;
-	    sizeY = 2;
-	    pins = new Pin[getPostCount()];
-
-	    pins[0] = new Pin(0, SIDE_W, "");
-	    pins[0].clock=true;
-	    pins[1] = new Pin(1, SIDE_E, "Q");
-	    pins[1].output=true;
+		sizeX = 2;
+		sizeY = 2;
+		pins = new Pin[getPostCount()];
+		
+		pins[0] = new Pin(0, SIDE_W, "");
+		pins[0].clock = true;
+		pins[1] = new Pin(1, SIDE_E, "Q");
+		pins[1].output = true;
+		if (hasReset())
+			pins[2] = new Pin(1, SIDE_W, "R");
 	}
-	int getPostCount() {
-	    return 2;
+	int getPostCount() { return hasReset() ? 3 : 2; }
+	int getVoltageSourceCount() { return 1; }
+	boolean hasOneShot() { return (flags & FLAG_ONE_SHOT) != 0; }
+	boolean hasReset() { return (flags & FLAG_HAS_RESET) != 0; }
+	
+	void getNextBit() {
+		pins[1].value = ((data >>> position) & 1) != 0;
+		position++;
 	}
-	int getVoltageSourceCount() {return 1;}
-
-void GetNextBit()
-{
-if(((data>>>position)&1)!=0)pins[1].value=true;
-else pins[1].value=false;
-position++;
-}
-
+	
 	void execute() {
-		if(oneshot)
-		{
-			if(sim.t-lastchangetime>0.005)
-			{
-				if(position<=8)GetNextBit();
-				lastchangetime=sim.t;
+		if (hasOneShot()) {
+			if (sim.t - lastchangetime > 0.005) {
+				if (position <= 8)
+					getNextBit();
+				lastchangetime = sim.t;
 			}
 		}
-		if(pins[0].value&&!clockstate)
-		{
-			clockstate=true;
-			if(oneshot)
-			{
-				position=0;
-			}
-			else
-			{
-				GetNextBit();
-				if(position>=8)position=0;
+		if (hasReset() && pins[2].value) {
+			// Suspended state (RESET raised)
+			position = (byte) (hasOneShot() ? 8 : 0);
+			pins[1].value = false;
+			clockstate = pins[0].value;
+		} else {
+			// Normal operation
+			if (pins[0].value != clockstate) {
+				// Edge transition
+				clockstate = pins[0].value;
+				if (clockstate) {
+					// Rising-edge event
+					clockstate = true;
+					if (hasOneShot()) {
+						position = 0;
+					} else {
+						getNextBit();
+						if(position >= 8)
+							position = 0;
+					}
+				}
 			}
 		}
-		if(!pins[0].value)clockstate=false;
-			
 	}
 	int getDumpType() { return 188; }
-
+	
 	String dump(){
-	    return super.dump()+" "+data+" "+oneshot;
+		return super.dump() + " " + data;
 	}
 	public EditInfo getEditInfo(int n) {
-	//My code
-	    if (n == 0) {
-		EditInfo ei = new EditInfo("", 0, -1, -1);
-		ei.checkbox = new Checkbox("Bit 0 set", (data&1) != 0);
-		return ei;
-	    }
-
-	    if (n == 1) {
-		EditInfo ei = new EditInfo("", 0, -1, -1);
-		ei.checkbox = new Checkbox("Bit 1 set", (data&2) != 0);
-		return ei;
-	    }
-	    if (n == 2) {
-		EditInfo ei = new EditInfo("", 0, -1, -1);
-		ei.checkbox = new Checkbox("Bit 2 set", (data&4) != 0);
-		return ei;
-	    }
-	    if (n == 3) {
-		EditInfo ei = new EditInfo("", 0, -1, -1);
-		ei.checkbox = new Checkbox("Bit 3 set", (data&8) != 0);
-		return ei;
-	    }
-
-	    if (n == 4) {
-		EditInfo ei = new EditInfo("", 0, -1, -1);
-		ei.checkbox = new Checkbox("Bit 4 set", (data&16) != 0);
-		return ei;
-	    }
-	    if (n == 5) {
-		EditInfo ei = new EditInfo("", 0, -1, -1);
-		ei.checkbox = new Checkbox("Bit 5 set", (data&32) != 0);
-		return ei;
-	    }
-
-	    if (n == 6) {
-		EditInfo ei = new EditInfo("", 0, -1, -1);
-		ei.checkbox = new Checkbox("Bit 6 set", (data&64) != 0);
-		return ei;
-	    }
-
-	    if (n == 7) {
-		EditInfo ei = new EditInfo("", 0, -1, -1);
-		ei.checkbox = new Checkbox("Bit 7 set", (data&128) != 0);
-		return ei;
-	    }
-	    if (n == 8) {
-		EditInfo ei = new EditInfo("", 0, -1, -1);
-		ei.checkbox = new Checkbox("One shot", oneshot);
-		return ei;
+		if (n < 2)
+			return super.getEditInfo(n);
+		if (n < 10) {
+			int bitIndex = n - 2;
+			EditInfo ei = new EditInfo("", 0, -1, -1);
+			ei.checkbox = new Checkbox("Bit "+(bitIndex+1)+" set", (data & (1<<bitIndex)) != 0);
+			return ei;
 		}
-	    return null;
+		if (n == 10) {
+			EditInfo ei = new EditInfo("", 0, -1, -1);
+			ei.checkbox = new Checkbox("One shot", hasOneShot());
+			return ei;
+		}
+		return null;
 	}
 	public void setEditValue(int n, EditInfo ei) {
-	    if (n == 0) {
-		if (ei.checkbox.getState())
-		    data|=1;
-		else
-		    data&= ~1;
-		setPoints();
-	    }
-	    if (n == 1) {
-		if (ei.checkbox.getState())
-		    data|=2;
-		else
-		    data&= ~2;
-		setPoints();
-	    }
-	    if (n == 2) {
-		if (ei.checkbox.getState())
-		    data|=4;
-		else
-		    data&= ~4;
-		setPoints();
-	    }
-	    if (n == 3) {
-		if (ei.checkbox.getState())
-		    data|=8;
-		else
-		    data&= ~8;
-		setPoints();
-	    }
-	    if (n == 4) {
-		if (ei.checkbox.getState())
-		    data|=16;
-		else
-		    data&= ~16;
-		setPoints();
-	    }
-	    if (n == 5) {
-		if (ei.checkbox.getState())
-		    data|=32;
-		else
-		    data&= ~32;
-		setPoints();
-	    }
-	    if (n == 6) {
-		if (ei.checkbox.getState())
-		    data|=64;
-		else
-		    data&= ~64;
-		setPoints();
-	    }
-	    if (n == 7) {
-		if (ei.checkbox.getState())
-		    data|=128;
-		else
-		    data&= ~128;
-		setPoints();
-	    }
-	    if (n == 8) {
-		if (ei.checkbox.getState())
-		{
-		oneshot=true;
-		position=8;
+		if (n < 2) {
+			super.setEditValue(n, ei);
+			return;
 		}
-		else
-		{
-		    position=0;
-		    oneshot=false;
+		if (n < 10) {
+			int bitIndex = n - 2;
+			int bit = 1 << bitIndex;
+			if (ei.checkbox.getState())
+				data |= bit;
+			else
+				data &= ~bit;
+			setPoints();
+			return;
 		}
-	    }
-
+		if (n == 10) {
+			if (ei.checkbox.getState()) {
+				flags |= FLAG_ONE_SHOT;
+				position = 8;
+			} else {
+				flags &= ~FLAG_ONE_SHOT;
+				position = 0;
+			}
+			return;
+		}
 	}
-
-    }
+}

--- a/src/com/lushprojects/circuitjs1/client/SeqGenElm.java
+++ b/src/com/lushprojects/circuitjs1/client/SeqGenElm.java
@@ -31,14 +31,14 @@ class SeqGenElm extends ChipElm {
 	
 	int bitPosition = 0;
 	int bitCount = 0;
-	byte data[];
+	int data[];
 	double lastchangetime = 0;
 	boolean clockstate = false;
 	
 	public SeqGenElm(int xx, int yy) {
 		super(xx, yy);
 		bitCount = 8;
-		data = new byte[] { 0 };
+		data = new int[] { 0 };
 		flags |= FLAG_NEW_VERSION;
 		//flags |= FLAG_HAS_RESET; // Uncomment this if somebody asks for a RESET pin on the SeqGen
 		setupPins();
@@ -54,11 +54,11 @@ class SeqGenElm extends ChipElm {
 				//The old sequence generator read bytes backwards, from right to left, and this needs to be corrected.
 				byte oldData = (byte)Integer.parseInt(st.nextToken());
 				byte newData = 0;
-				for (int i = 0; i < Byte.SIZE; i++)
-					newData |= oldData & ((~(Byte.MAX_VALUE - 1) >> i) != 0 ? (1 << i) : 0);
+				for (int i = 0; i < Integer.SIZE; i++)
+					newData |= oldData & ((~(Integer.MAX_VALUE - 1) >> i) != 0 ? (1 << i) : 0);
 				
 				bitCount = 8;
-				data = new byte[] { newData };
+				data = new int[] { newData };
 				
 				if (st.hasMoreTokens()) {
 					if (Boolean.parseBoolean(st.nextToken())) {
@@ -70,17 +70,17 @@ class SeqGenElm extends ChipElm {
 			} else {
 				// Load normally
 				bitCount = Integer.parseInt(st.nextToken());
-				data = new byte[(int)(bitCount / Byte.SIZE) + (bitCount % Byte.SIZE != 0 ? 1 : 0)]; //Allocate enough bytes to fit the requested number of bits
+				data = new int[(bitCount / Integer.SIZE) + (bitCount % Integer.SIZE != 0 ? 1 : 0)]; //Allocate enough bytes to fit the requested number of bits
 				for (int i = 0; i < data.length; i++)
-					data[i] = Byte.parseByte(st.nextToken());
+					data[i] = Integer.parseInt(st.nextToken());
 			}
 		} catch (NoSuchElementException e) {
 			// Corrupted element: Data is incomplete
 		}
 		
 		// Ensure bitCount does not exceed the amount of data we have. (This can happen if there was an error)
-		if (bitCount > data.length * Byte.SIZE)
-			bitCount = data.length * Byte.SIZE;
+		if (bitCount > data.length * Integer.SIZE)
+			bitCount = data.length * Integer.SIZE;
 		
 		if (hasOneShot())
 			bitPosition = bitCount; //Set the pos to the end so that this seqgen's one-shot mode doesn't trigger immediately
@@ -108,7 +108,7 @@ class SeqGenElm extends ChipElm {
 		if (data.length > 0 && bitCount > 0) {
 			if (bitPosition >= bitCount)
 				bitPosition = 0;
-			pins[1].value = (data[bitPosition / Byte.SIZE] & (1 << (bitPosition % Byte.SIZE))) != 0;
+			pins[1].value = (data[bitPosition / Integer.SIZE] & (1 << (bitPosition % Integer.SIZE))) != 0;
 			bitPosition++;
 		} else {
 			pins[1].value = false;
@@ -159,7 +159,7 @@ class SeqGenElm extends ChipElm {
 		sb.append(bitCount);
 		for (int i = 0; i < data.length; i++) {
 			sb.append(' ');
-			sb.append(Byte.toString(data[i]));
+			sb.append(Integer.toString(data[i]));
 		}
 		return sb.toString();
 	}
@@ -177,7 +177,7 @@ class SeqGenElm extends ChipElm {
         	ei.textArea.setVisibleLines(5);
         	StringBuilder sb = new StringBuilder(bitCount);
         	for (int i = 0; i < bitCount; i++)
-        		sb.append((data[i / Byte.SIZE] & (1 << (i % Byte.SIZE))) != 0 ? '1' : '0');
+        		sb.append((data[i / Integer.SIZE] & (1 << (i % Integer.SIZE))) != 0 ? '1' : '0');
         	ei.textArea.setText(sb.toString());
 			return ei;
 		}
@@ -207,7 +207,7 @@ class SeqGenElm extends ChipElm {
 				if (c == '0' || c == '1')
 					bitCount++;
 			}
-			data = new byte[bitCount / Byte.SIZE];
+			data = new int[bitCount / Integer.SIZE];
 			
 			// Fill the data array
 			bitCount = 0;
@@ -215,7 +215,7 @@ class SeqGenElm extends ChipElm {
 				char c = s.charAt(i);
 				if (c == '0' || c == '1') {
 					if (c == '1')
-						data[bitCount / Byte.SIZE] = (byte) (data[bitCount / Byte.SIZE] | (1 << (bitCount % Byte.SIZE)));
+						data[bitCount / Integer.SIZE] = (byte) (data[bitCount / Integer.SIZE] | (1 << (bitCount % Integer.SIZE)));
 					bitCount++;
 				}
 			}

--- a/src/com/lushprojects/circuitjs1/client/SeqGenElm.java
+++ b/src/com/lushprojects/circuitjs1/client/SeqGenElm.java
@@ -83,7 +83,7 @@ class SeqGenElm extends ChipElm {
 			bitCount = data.length * Byte.SIZE;
 		
 		if (hasOneShot())
-			bitPosition = data.length * Byte.SIZE; //Set the pos to the end so that this seqgen's one-shot mode doesn't trigger immediately
+			bitPosition = bitCount; //Set the pos to the end so that this seqgen's one-shot mode doesn't trigger immediately
 	}
 	
 	String getChipName() { return "sequence generator"; }
@@ -106,7 +106,7 @@ class SeqGenElm extends ChipElm {
 	
 	void nextBit() {
 		if (data.length > 0 && bitCount > 0) {
-			if (bitPosition / Byte.SIZE >= data.length)
+			if (bitPosition >= bitCount)
 				bitPosition = 0;
 			pins[1].value = (data[bitPosition / Byte.SIZE] & (1 << (bitPosition % Byte.SIZE))) != 0;
 			bitPosition++;
@@ -140,7 +140,7 @@ class SeqGenElm extends ChipElm {
 				// One-shot mode
 				if (sim.t - lastchangetime > 0.005) {
 					CirSim.console("Tick");
-					if (bitPosition / Byte.SIZE < data.length)
+					if (bitPosition < bitCount)
 						nextBit();
 					if (sim.t - lastchangetime > 0.005 * 2.0)
 						lastchangetime = sim.t;
@@ -192,7 +192,7 @@ class SeqGenElm extends ChipElm {
 			if (ei.checkbox.getState() != ((flags & FLAG_ONE_SHOT) != 0)) { //value changed
 				flags = ei.changeFlag(flags, FLAG_ONE_SHOT);
 				if (hasOneShot())
-					bitPosition = data.length * Byte.SIZE; //Ditto
+					bitPosition = bitCount; //Ditto
 			}
 			return;
 		}
@@ -221,7 +221,7 @@ class SeqGenElm extends ChipElm {
 			}
 			
 			if (hasOneShot() && wasEmpty)
-				bitPosition = data.length * Byte.SIZE; //Ditto
+				bitPosition = bitCount; //Ditto
 			
 			return;
 		}

--- a/src/com/lushprojects/circuitjs1/client/SeqGenElm.java
+++ b/src/com/lushprojects/circuitjs1/client/SeqGenElm.java
@@ -187,7 +187,7 @@ class SeqGenElm extends ChipElm {
 				char c = s.charAt(i);
 				if (c == '0' || c == '1') {
 					if (c == '1')
-						data[bitCount / Integer.SIZE] = (byte) (data[bitCount / Integer.SIZE] | (1 << (bitCount % Integer.SIZE)));
+						data[bitCount / Integer.SIZE] |= (1 << (bitCount % Integer.SIZE));
 					bitCount++;
 				}
 			}

--- a/src/com/lushprojects/circuitjs1/client/SeqGenElm.java
+++ b/src/com/lushprojects/circuitjs1/client/SeqGenElm.java
@@ -122,11 +122,8 @@ class SeqGenElm extends ChipElm {
 			if (pins[0].value != clockstate) {
 				// Edge transition
 				clockstate = pins[0].value;
-				if (clockstate) {
-					// Rising-edge event
-					clockstate = true;
+				if (clockstate) // Rising-edge event
 					nextBit();
-				}
 			}
 		}
 	}

--- a/src/com/lushprojects/circuitjs1/client/SeqGenElm.java
+++ b/src/com/lushprojects/circuitjs1/client/SeqGenElm.java
@@ -143,6 +143,8 @@ class SeqGenElm extends ChipElm {
 			}
 			if (hasOneShot()) {
 				// One-shot mode
+				if (lastchangetime > sim.t)
+					lastchangetime = 0.0;
 				if (sim.t - lastchangetime >= oneShotInterval) {
 					if (bitPosition < bitCount)
 						nextBit();


### PR DESCRIPTION
Various major DRY violations are now gone.
The class now inherits ChipElm's edit info. As such, the chip can now be flipped on both X and Y axes. Flip Y isn't particularly useful, but flip X should be very useful for this element.
"One shot" is now stored in the element flag instead of a boolean. This should be backwards compatible but I've only tested this in-vitro and not fully from an example circuit.
This also adds a reset pin, which had a function (``hasReset``) but was never properly implemented. Old circuits should not feature the reset pin.