### PR TITLE
Increase maximum resistor scroll value to 10M

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/ScrollValuePopup.java
+++ b/src/com/lushprojects/circuitjs1/client/ScrollValuePopup.java
@@ -90,7 +90,7 @@ public class ScrollValuePopup extends PopupPanel implements MouseOutHandler, Mou
 	private void setupValues() {
 		if (myElm instanceof ResistorElm) {
 			minpow=0;
-			maxpow=6;
+			maxpow=7;
 		} 
 		if (myElm instanceof CapacitorElm) {
 			minpow=-11;


### PR DESCRIPTION
Sometimes I find that only being able to set resistor values up to 1M by scrolling is a nuisance, in that one has to manually edit the value to input 2.2M, 4.7M or whatever.
Maybe increaseing the maximum value that can be set by scrolling to 10M could make sense.