### PR TITLE
Introduce a new Performance Monitor and Developer Mode

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/CirSim.java
+++ b/src/com/lushprojects/circuitjs1/client/CirSim.java
@@ -211,6 +211,7 @@ MouseOutHandler, MouseWheelHandler {
     int timeStepCount;
     
     boolean adjustTimeStep;
+    boolean developerMode;
     static final int HINT_LC = 1;
     static final int HINT_RC = 2;
     static final int HINT_3DB_C = 3;
@@ -1475,8 +1476,7 @@ MouseOutHandler, MouseWheelHandler {
         }
 
         // for some mouse modes, what matters is not the posts but the endpoints (which
-        // are only
-        // the same for 2-terminal elements). We draw those now if needed
+        // are only the same for 2-terminal elements). We draw those now if needed
         if (tempMouseMode == MODE_DRAG_ROW || 
             tempMouseMode == MODE_DRAG_COLUMN || 
             tempMouseMode == MODE_DRAG_POST || 
@@ -1538,23 +1538,15 @@ MouseOutHandler, MouseWheelHandler {
         drawBottomArea(g);
         perfmon.stopContext();
 
+        g.setColor(Color.white);
+        
+        perfmon.stopContext(); // graphics
+        
         if (stopElm != null && stopElm != mouseElm)
             stopElm.setMouseElm(false);
         
         frames++;
 
-        perfmon.stopContext(); // graphics
-
-        g.setColor(Color.white);
-        
-        /*int height = 10;
-        int increment = 15;
-        g.drawString("Framerate: " + CircuitElm.showFormat.format(framerate), 10, height);
-        g.drawString("Steprate: " + CircuitElm.showFormat.format(steprate), 10, height += increment);
-        g.drawString("Steprate/iter: " + CircuitElm.showFormat.format(steprate / getIterCount()), 10, height += increment);
-        g.drawString("iterc: " + CircuitElm.showFormat.format(getIterCount()), 10, height += increment);
-        g.drawString("Frames: " + frames, 10, height += increment);*/
-        
         // if we did DC analysis, we need to re-analyze the circuit with that flag
         // cleared.
         if (dcAnalysisFlag) {
@@ -1565,15 +1557,24 @@ MouseOutHandler, MouseWheelHandler {
         lastFrameTime = lastTime;
 
         perfmon.stopContext(); // updateCircuit
-
-        String perfmonResult = PerfMonitor.buildString(perfmon).toString();
-        console(perfmonResult);
-
-        /*String[] splits = perfmonResult.split("\n");
-        int rootXValue = 200;
-        for (int x = 0; x < splits.length; x++) {
-            g.drawString(splits[x], 10, rootXValue + (15 * x));
-        }*/
+        
+        if (developerMode) {
+            int height = 15;
+            int increment = 15;
+            g.drawString("Framerate: " + CircuitElm.showFormat.format(framerate), 10, height);
+            g.drawString("Steprate: " + CircuitElm.showFormat.format(steprate), 10, height += increment);
+            g.drawString("Steprate/iter: " + CircuitElm.showFormat.format(steprate / getIterCount()), 10, height += increment);
+            g.drawString("iterc: " + CircuitElm.showFormat.format(getIterCount()), 10, height += increment);
+            g.drawString("Frames: " + frames, 10, height += increment);
+            
+            height += (increment * 2);
+            
+            String perfmonResult = PerfMonitor.buildString(perfmon).toString();
+            String[] splits = perfmonResult.split("\n");
+            for (int x = 0; x < splits.length; x++) {
+                g.drawString(splits[x], 10, height + (increment * x));
+            }
+        }
         
         // This should always be the last 
         // thing called by updateCircuit();

--- a/src/com/lushprojects/circuitjs1/client/EditOptions.java
+++ b/src/com/lushprojects/circuitjs1/client/EditOptions.java
@@ -66,11 +66,16 @@ class EditOptions implements Editable {
 		if (n == 8)
 		    return new EditInfo("# of Decimal Digits (long format)", CircuitElm.decimalDigits);
 		if (n == 9) {
+            EditInfo ei = new EditInfo("", 0, -1, -1);
+            ei.checkbox = new Checkbox("Developer Mode", sim.developerMode);
+            return ei;
+        }
+		if (n == 10) {
 		    EditInfo ei = new EditInfo("", 0, -1, -1);
 		    ei.checkbox = new Checkbox("Auto-Adjust Timestep", sim.adjustTimeStep);
 		    return ei;
 		}
-		if (n == 10 && sim.adjustTimeStep)
+		if (n == 11 && sim.adjustTimeStep)
 		    return new EditInfo("Minimum time step size (s)", sim.minTimeStep, 0, 0);
 
 		return null;
@@ -133,11 +138,13 @@ class EditOptions implements Editable {
 		    CircuitElm.setDecimalDigits((int)ei.value, true, true);
 		if (n == 8)
 		    CircuitElm.setDecimalDigits((int)ei.value, false, true);
-		if (n == 9) {
+		if (n == 9)
+	            sim.developerMode = ei.checkbox.getState();
+		if (n == 10) {
 		    sim.adjustTimeStep = ei.checkbox.getState();
 		    ei.newDialog = true;
 		}
-		if (n == 10 && ei.value > 0)
+		if (n == 11 && ei.value > 0)
 			sim.minTimeStep = ei.value;
 	}
 	

--- a/src/com/lushprojects/circuitjs1/client/util/PerfMonitor.java
+++ b/src/com/lushprojects/circuitjs1/client/util/PerfMonitor.java
@@ -1,0 +1,99 @@
+package com.lushprojects.circuitjs1.client.util;
+
+import java.util.*;
+
+public class PerfMonitor {
+    
+    String rootCtxName;
+    PerfEntry rootCtx;
+    PerfEntry ctx;
+    
+    public PerfMonitor() {
+    
+    }
+
+    public void startContext(String name) {
+        PerfEntry newEntry = startNewEntry(ctx);
+        if (ctx == null) {
+            ctx = newEntry;
+            if (rootCtx == null) {
+                rootCtxName = name;
+                rootCtx = ctx;
+            }
+        } else {
+            if (ctx.AddChild(name, newEntry)) {
+                ctx = newEntry;
+            }
+        }
+    }
+    
+    public void stopContext() {
+        if (ctx != null) {
+            ctx.endTime = getTime();
+            ctx.length = ctx.endTime - ctx.startTime;
+            ctx = ctx.parent;
+        }
+    }
+    
+    private PerfEntry startNewEntry(PerfEntry parent) {
+        PerfEntry newEntry = new PerfEntry(parent);
+        newEntry.startTime = getTime();
+        return newEntry;
+    }
+    
+    private long getTime() {
+        return System.currentTimeMillis();
+    }
+    
+    public static StringBuilder buildString(PerfMonitor mon) {
+        StringBuilder sb = new StringBuilder();
+        buildStringInternal(sb, mon.rootCtxName, mon.rootCtx, 0);
+        return sb;
+    } 
+    
+    private static void buildStringInternal(StringBuilder sb, String name, PerfEntry entry, int depth) {
+        for (int x = 0; x < depth; x++) {
+            sb.append("-");
+        }
+        sb.append(name);
+        sb.append(": ");
+        sb.append(entry.length);
+        sb.append("\n");
+        Set<String> keys = entry.children.keySet();
+        for (String key : keys){
+            PerfEntry child = entry.children.get(key);
+            buildStringInternal(sb, key, child, depth + 1);
+        }
+    }
+    
+    class PerfEntry {
+    
+        public PerfEntry parent;
+        public HashMap<String, PerfEntry> children;
+            
+        public long startTime;
+        public long endTime;
+        public long length;
+        
+        public PerfEntry(PerfEntry p) {
+            parent = p;
+            children = new HashMap<String, PerfEntry>();
+        }
+        
+        public boolean AddChild(String name, PerfEntry entry) {
+            if (!children.containsKey(name)) {
+                children.put(name, entry);
+                return true;
+            }
+            return false;
+        }
+        
+        public PerfEntry GetChild(String name) {
+            if (children.containsKey(name)) {
+                return children.get(name);
+            }
+            return null;
+        }
+    }
+    
+}

--- a/src/com/lushprojects/circuitjs1/client/util/PerfMonitor.java
+++ b/src/com/lushprojects/circuitjs1/client/util/PerfMonitor.java
@@ -41,10 +41,6 @@ public class PerfMonitor {
         return newEntry;
     }
     
-    private long getTime() {
-        return System.currentTimeMillis();
-    }
-    
     public static StringBuilder buildString(PerfMonitor mon) {
         StringBuilder sb = new StringBuilder();
         buildStringInternal(sb, mon.rootCtxName, mon.rootCtx, 0);
@@ -66,14 +62,27 @@ public class PerfMonitor {
         }
     }
     
+    private static native float getTime() /*-{
+        // https://stackoverflow.com/questions/6875625
+        if (window.performance.now) {
+            return window.performance.now();
+        } else {
+            if (window.performance.webkitNow) {
+                return window.performance.webkitNow();
+            } else {
+                return new Date().getTime();
+            }
+        }
+    }-*/;
+
     class PerfEntry {
     
         public PerfEntry parent;
         public HashMap<String, PerfEntry> children;
             
-        public long startTime;
-        public long endTime;
-        public long length;
+        public float startTime;
+        public float endTime;
+        public float length;
         
         public PerfEntry(PerfEntry p) {
             parent = p;


### PR DESCRIPTION
**NOTE:** It'll be easiest to view this PR with [whitespace ignored](https://github.blog/2018-05-01-ignore-white-space-in-code-review/). ([quick link](https://github.com/pfalstad/circuitjs1/pull/20/files?diff=unified&w=1))

This PR introduces a new `PerformanceMonitor` that uses a high precision timer to get a better view of how the sim is performing. The monitor can be split into different contexts that can be nested.

![2022-04-14 22_37_24-127 0 0 1_8888_circuitjs html](https://user-images.githubusercontent.com/6798456/163527420-c90f536a-e04f-4705-a148-e4a10c656a2d.png)

```
updateCircuit(): 2.99   // The whole sim took 2.299 ms
-runCircuit(): 0.2      // This function took 0.2 ms
-graphics: 2            // This is showing the total of the following two child times (2ms)
--elm.draw(): 0.2       // Took 0.2ms to draw all the elements
--drawBottomArea(): 1.7 // Took 1.7ms to draw the scopes
```

Additionally, this developer info can now be togged without recompiling via a new option in the settings.

![2022-04-14 22_43_19-127 0 0 1_8888_circuitjs html](https://user-images.githubusercontent.com/6798456/163527850-5bb0cec1-8505-4623-9d62-7699289158b4.png)

This PR is very much in line with the kind of contributions I want to make to the project, refactoring + new small features where it makes sense.

@pfalstad would you consider opening the issues page for this fork of the project? Using the sharpie7 issues page dosen't seem appropriate.