### PR TITLE
Refactoring and cleanup of the entry point for readability.

### DIFF
--- a/src/com/lushprojects/circuitjs1/circuitjs1.gwt.xml
+++ b/src/com/lushprojects/circuitjs1/circuitjs1.gwt.xml
@@ -4,4 +4,4 @@
     <inherits name="com.google.gwt.http.HTTP" />
     <inherits name='com.google.gwt.user.theme.clean.Clean'/>
     <entry-point class="com.lushprojects.circuitjs1.client.circuitjs1" />
- </module>
+</module>

--- a/src/com/lushprojects/circuitjs1/client/circuitjs1.java
+++ b/src/com/lushprojects/circuitjs1/client/circuitjs1.java
@@ -51,16 +51,18 @@ public class circuitjs1 implements EntryPoint {
         loadLocale();
     }
 
-    native String language() /*-{ // Modified to support Electron which return empty array for navigator.languages
-      if (navigator.languages) {
-        if (navigator.languages.length>0)
-          return navigator.languages[0];
-        else
-          return "en-US";
-      } else {
-      	return  (navigator.language || navigator.userLanguage) ;  
-      }
-  }-*/;
+    native String language() /*-{
+        if (navigator.languages) {
+            if (navigator.languages.length>0) {
+                return navigator.languages[0];
+            } else {
+                 // In Electron, navigator.languages returns an empty array
+                return "en-US";
+            }
+        } else {
+            return  (navigator.language || navigator.userLanguage);  
+        }
+    }-*/;
 
     void loadLocale() {
         String url;

--- a/src/com/lushprojects/circuitjs1/client/circuitjs1.java
+++ b/src/com/lushprojects/circuitjs1/client/circuitjs1.java
@@ -44,7 +44,10 @@ public class circuitjs1 implements EntryPoint {
 
     static CirSim mysim;
 
+    // This is the program entrypoint! 
+    // Called by gtw automagically (see circuitjs1.gwt.xml)
     public void onModuleLoad() {
+        // loadLocale() launches the sim after determining the language (see below)
         loadLocale();
     }
 
@@ -72,7 +75,7 @@ public class circuitjs1 implements EntryPoint {
             if (lang == null)
                 lang = language();
         }
-        
+
         GWT.log("got language " + lang);
 
         // check for Taiwan Chinese. Otherwise, strip the region code
@@ -153,7 +156,7 @@ public class circuitjs1 implements EntryPoint {
                 mysim.setiFrameHeight();
             }
         });
-        
+
         mysim.updateCircuit();
     }
 

--- a/src/com/lushprojects/circuitjs1/client/circuitjs1.java
+++ b/src/com/lushprojects/circuitjs1/client/circuitjs1.java
@@ -47,20 +47,19 @@ public class circuitjs1 implements EntryPoint {
 
     public void onModuleLoad() {
         localizationMap = new HashMap<String, String>();
-
         loadLocale();
     }
 
     native String language() /*-{
         if (navigator.languages) {
-            if (navigator.languages.length>0) {
+            if (navigator.languages.length > 0) {
                 return navigator.languages[0];
             } else {
-                 // In Electron, navigator.languages returns an empty array
+                // In Electron, navigator.languages returns an empty array
                 return "en-US";
             }
         } else {
-            return  (navigator.language || navigator.userLanguage);  
+            return (navigator.language || navigator.userLanguage);  
         }
     }-*/;
 
@@ -75,6 +74,7 @@ public class circuitjs1 implements EntryPoint {
             if (lang == null)
                 lang = language();
         }
+        
         GWT.log("got language " + lang);
 
         // check for Taiwan Chinese. Otherwise, strip the region code
@@ -88,6 +88,7 @@ public class circuitjs1 implements EntryPoint {
             loadSimulator();
             return;
         }
+        
         url = GWT.getModuleBaseURL() + "locale_" + lang + ".txt";
         RequestBuilder requestBuilder = new RequestBuilder(RequestBuilder.GET, url);
         try {
@@ -97,15 +98,15 @@ public class circuitjs1 implements EntryPoint {
                 }
 
                 public void onResponseReceived(Request request, Response response) {
-                    // processing goes here
                     if (response.getStatusCode() == Response.SC_OK) {
                         String text = response.getText();
                         processLocale(text);
-                        // end or processing
                     } else {
-                        GWT.log("Bad file server response:" + response.getStatusText());
-                        loadSimulator();
+                        GWT.log("Bad file server response: " + response.getStatusText());
+                        // if there was an error in retrieving the 
+                        // language, default to English (empty map)
                     }
+                    loadSimulator();
                 }
             });
         } catch (RequestException e) {
@@ -116,8 +117,7 @@ public class circuitjs1 implements EntryPoint {
 
     void processLocale(String data) {
         String lines[] = data.split("\r?\n");
-        int i;
-        for (i = 0; i != lines.length; i++) {
+        for (int i = 0; i != lines.length; i++) {
             String line = lines[i];
             if (line.length() == 0)
                 continue;
@@ -126,8 +126,10 @@ public class circuitjs1 implements EntryPoint {
                 continue;
             }
             int q2 = line.indexOf('"', 1);
-            if (q2 < 0 || line.charAt(q2 + 1) != '=' || line.charAt(q2 + 2) != '"'
-                    || line.charAt(line.length() - 1) != '"') {
+            if ((q2 < 0)
+                || (line.charAt(q2 + 1) != '=')
+                || (line.charAt(q2 + 2) != '"')
+                || (line.charAt(line.length() - 1) != '"')) {
                 CirSim.console("ignoring line in string catalog: " + line);
                 continue;
             }
@@ -135,7 +137,6 @@ public class circuitjs1 implements EntryPoint {
             String str2 = line.substring(q2 + 3, line.length() - 1);
             localizationMap.put(str1, str2);
         }
-        loadSimulator();
     }
 
     public void loadSimulator() {
@@ -149,7 +150,7 @@ public class circuitjs1 implements EntryPoint {
                 mysim.setiFrameHeight();
             }
         });
-
+        
         mysim.updateCircuit();
     }
 

--- a/src/com/lushprojects/circuitjs1/client/circuitjs1.java
+++ b/src/com/lushprojects/circuitjs1/client/circuitjs1.java
@@ -21,42 +21,6 @@ package com.lushprojects.circuitjs1.client;
 
 import java.util.HashMap;
 
-//CirSim.java (c) 2010 - 2017 by Paul Falstad
-//GWT conversion (c) 2015 - 2017 by Iain Sharp
-
-//Version History
-
-//v1.9.1js 16-11-06 Iain Sharp
-//Add import of file from CORS compatible link
-//v1.9.0js 16-11-06 Iain Sharp
-// Add URL-shortener and Dropbox integration
-//v1.8.0js 16-10-30 Iain Sharp
-// Incorporate latest Falstad updates. Improvements to UI and bug fixes
-//v1.0.1 15-06-15
-//Convert source code to GPLv2
-//Incorporate example files in to project
-//v1.0.0 15-06-05
-//Import/export to/from text now fixed
-//v0.1.3 15-06-03
-//Handles appear on components when dragged
-//Improved integration of potentiometers and VarRails with sliders - colour changes and support
-//for scroll wheel.
-//v0.1.2 15-06-01
-//Automatic selection of post drag mode when user is near a handle in select mode
-//Visual appearance of handles changed
-//Accepts "2k2" style engineers short-hand for component values
-//Menus prettified
-//v0.1.1 
-//Bug fix for PNP transistors and past
-//v0.1.0 - 
-//Initial test release on web
-
-//ToDos
-// Scope improvements
-//UI improvements
-//Potentiometer - improve drawing code
-//Coil drawing - find out why my alternative code doesn't work
-
 import com.google.gwt.core.client.EntryPoint;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.logical.shared.ResizeEvent;
@@ -178,23 +142,13 @@ public class circuitjs1 implements EntryPoint {
         mysim.init();
 
         Window.addResizeHandler(new ResizeHandler() {
-
             public void onResize(ResizeEvent event) {
                 mysim.setCanvasSize();
                 mysim.setiFrameHeight();
-
             }
         });
 
-        /*
-         * Window.addWindowClosingHandler(new Window.ClosingHandler() {
-         * 
-         * public void onWindowClosing(ClosingEvent event) {
-         * event.setMessage("Are you sure?"); } });
-         */
-
         mysim.updateCircuit();
-
     }
 
 }

--- a/src/com/lushprojects/circuitjs1/client/circuitjs1.java
+++ b/src/com/lushprojects/circuitjs1/client/circuitjs1.java
@@ -43,10 +43,8 @@ public class circuitjs1 implements EntryPoint {
     public static final boolean shortRelaySupported = true;
 
     static CirSim mysim;
-    HashMap<String, String> localizationMap;
 
     public void onModuleLoad() {
-        localizationMap = new HashMap<String, String>();
         loadLocale();
     }
 
@@ -85,7 +83,8 @@ public class circuitjs1 implements EntryPoint {
 
         if (lang.startsWith("en")) {
             // no need to load locale file for English
-            loadSimulator();
+            HashMap<String, String> localizationMap = new HashMap<String, String>();
+            loadSimulator(localizationMap);
             return;
         }
         
@@ -98,15 +97,17 @@ public class circuitjs1 implements EntryPoint {
                 }
 
                 public void onResponseReceived(Request request, Response response) {
+                    HashMap<String, String> localizationMap;
                     if (response.getStatusCode() == Response.SC_OK) {
                         String text = response.getText();
-                        processLocale(text);
+                        localizationMap = processLocale(text);
                     } else {
                         GWT.log("Bad file server response: " + response.getStatusText());
                         // if there was an error in retrieving the 
                         // language, default to English (empty map)
+                        localizationMap = new HashMap<String, String>();
                     }
-                    loadSimulator();
+                    loadSimulator(localizationMap);
                 }
             });
         } catch (RequestException e) {
@@ -115,7 +116,8 @@ public class circuitjs1 implements EntryPoint {
 
     }
 
-    void processLocale(String data) {
+    HashMap<String, String> processLocale(String data) {
+        HashMap<String, String> localizationMap = new HashMap<String, String>();
         String lines[] = data.split("\r?\n");
         for (int i = 0; i != lines.length; i++) {
             String line = lines[i];
@@ -137,11 +139,12 @@ public class circuitjs1 implements EntryPoint {
             String str2 = line.substring(q2 + 3, line.length() - 1);
             localizationMap.put(str1, str2);
         }
+        return localizationMap;
     }
 
-    public void loadSimulator() {
+    public void loadSimulator(HashMap<String, String> localizationMap) {
+        CirSim.localizationMap = localizationMap;
         mysim = new CirSim();
-        mysim.localizationMap = localizationMap;
         mysim.init();
 
         Window.addResizeHandler(new ResizeHandler() {

--- a/src/com/lushprojects/circuitjs1/client/circuitjs1.java
+++ b/src/com/lushprojects/circuitjs1/client/circuitjs1.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 //GWT conversion (c) 2015 - 2017 by Iain Sharp
 
 //Version History
+
 //v1.9.1js 16-11-06 Iain Sharp
 //Add import of file from CORS compatible link
 //v1.9.0js 16-11-06 Iain Sharp
@@ -50,7 +51,6 @@ import java.util.HashMap;
 //v0.1.0 - 
 //Initial test release on web
 
-
 //ToDos
 // Scope improvements
 //UI improvements
@@ -70,24 +70,24 @@ import com.google.gwt.storage.client.Storage;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.Window.ClosingEvent;
 
-
 public class circuitjs1 implements EntryPoint {
 
-	public static final String versionString="2.7.1js";
-	
-	// Set to true if the server runs the shortrelay.php file in the same directory as the circuit simulator
-	public static final boolean shortRelaySupported = true;
+    public static final String versionString = "2.7.1js";
 
-	static CirSim mysim;
-	HashMap<String,String> localizationMap;
-	
-  public void onModuleLoad() {
-      localizationMap = new HashMap<String,String>();
-      
-      loadLocale();
-  }
+    // Set to true if the server runs the shortrelay.php file in the same directory
+    // as the circuit simulator
+    public static final boolean shortRelaySupported = true;
 
-  native String language()  /*-{ // Modified to support Electron which return empty array for navigator.languages
+    static CirSim mysim;
+    HashMap<String, String> localizationMap;
+
+    public void onModuleLoad() {
+        localizationMap = new HashMap<String, String>();
+
+        loadLocale();
+    }
+
+    native String language() /*-{ // Modified to support Electron which return empty array for navigator.languages
       if (navigator.languages) {
         if (navigator.languages.length>0)
           return navigator.languages[0];
@@ -98,110 +98,103 @@ public class circuitjs1 implements EntryPoint {
       }
   }-*/;
 
-  void loadLocale() {
-  	String url;
-	QueryParameters qp = new QueryParameters();
-	String lang = qp.getValue("lang");
-	if (lang == null) {
-	    Storage stor = Storage.getLocalStorageIfSupported();
-	    if (stor != null)
-		lang = stor.getItem("language");
-	    if (lang == null)
-		lang = language();
-	}
-  	GWT.log("got language " + lang);
-  	
-  	// check for Taiwan Chinese.  Otherwise, strip the region code
-  	if (lang.equalsIgnoreCase("zh-tw") || lang.equalsIgnoreCase("zh-cht"))
-  	    lang = "zh-tw";
-  	else
-  	    lang = lang.replaceFirst("-.*", "");
-  	
-  	if (lang.startsWith("en")) {
-  	    // no need to load locale file for English
-  	    loadSimulator();
-  	    return;
-  	}
-  	url = GWT.getModuleBaseURL()+"locale_" + lang + ".txt";
-		RequestBuilder requestBuilder = new RequestBuilder(RequestBuilder.GET, url);
-		try {
-			requestBuilder.sendRequest(null, new RequestCallback() {
-				public void onError(Request request, Throwable exception) {
-					GWT.log("File Error Response", exception);
-				}
+    void loadLocale() {
+        String url;
+        QueryParameters qp = new QueryParameters();
+        String lang = qp.getValue("lang");
+        if (lang == null) {
+            Storage stor = Storage.getLocalStorageIfSupported();
+            if (stor != null)
+                lang = stor.getItem("language");
+            if (lang == null)
+                lang = language();
+        }
+        GWT.log("got language " + lang);
 
-				public void onResponseReceived(Request request, Response response) {
-					// processing goes here
-					if (response.getStatusCode()==Response.SC_OK) {
-					String text = response.getText();
-					processLocale(text);
-					// end or processing
-					}
-					else {
-						GWT.log("Bad file server response:"+response.getStatusText() );
-						loadSimulator();
-					}
-				}
-			});
-		} catch (RequestException e) {
-			GWT.log("failed file reading", e);
-		}
+        // check for Taiwan Chinese. Otherwise, strip the region code
+        if (lang.equalsIgnoreCase("zh-tw") || lang.equalsIgnoreCase("zh-cht"))
+            lang = "zh-tw";
+        else
+            lang = lang.replaceFirst("-.*", "");
 
-  }
-  
-  void processLocale(String data) {
-      String lines[] = data.split("\r?\n");
-      int i;
-      for (i = 0; i != lines.length; i++) {
-	  String line = lines[i];
-	  if (line.length() == 0)
-	      continue;
-	  if (line.charAt(0) != '"') {
-	      CirSim.console("ignoring line in string catalog: " + line);
-	      continue;
-	  }
-	  int q2 = line.indexOf('"', 1);
-	  if (q2 < 0 || line.charAt(q2+1) != '=' || line.charAt(q2+2) != '"' ||
-		  line.charAt(line.length()-1) != '"') {
-	      CirSim.console("ignoring line in string catalog: " + line);
-	      continue;
-	  }
-	  String str1 = line.substring(1, q2);
-	  String str2 = line.substring(q2+3, line.length()-1);
-	  localizationMap.put(str1, str2);
-      }
-      loadSimulator();
-  }
-  
-  public void loadSimulator() {
-	  mysim = new CirSim();
-	  mysim.localizationMap = localizationMap;
-	  mysim.init();
+        if (lang.startsWith("en")) {
+            // no need to load locale file for English
+            loadSimulator();
+            return;
+        }
+        url = GWT.getModuleBaseURL() + "locale_" + lang + ".txt";
+        RequestBuilder requestBuilder = new RequestBuilder(RequestBuilder.GET, url);
+        try {
+            requestBuilder.sendRequest(null, new RequestCallback() {
+                public void onError(Request request, Throwable exception) {
+                    GWT.log("File Error Response", exception);
+                }
 
-	    Window.addResizeHandler(new ResizeHandler() {
-	    	 
-            public void onResize(ResizeEvent event)
-            {               
-            	mysim.setCanvasSize();
-                mysim.setiFrameHeight();	
-                	
+                public void onResponseReceived(Request request, Response response) {
+                    // processing goes here
+                    if (response.getStatusCode() == Response.SC_OK) {
+                        String text = response.getText();
+                        processLocale(text);
+                        // end or processing
+                    } else {
+                        GWT.log("Bad file server response:" + response.getStatusText());
+                        loadSimulator();
+                    }
+                }
+            });
+        } catch (RequestException e) {
+            GWT.log("failed file reading", e);
+        }
+
+    }
+
+    void processLocale(String data) {
+        String lines[] = data.split("\r?\n");
+        int i;
+        for (i = 0; i != lines.length; i++) {
+            String line = lines[i];
+            if (line.length() == 0)
+                continue;
+            if (line.charAt(0) != '"') {
+                CirSim.console("ignoring line in string catalog: " + line);
+                continue;
+            }
+            int q2 = line.indexOf('"', 1);
+            if (q2 < 0 || line.charAt(q2 + 1) != '=' || line.charAt(q2 + 2) != '"'
+                    || line.charAt(line.length() - 1) != '"') {
+                CirSim.console("ignoring line in string catalog: " + line);
+                continue;
+            }
+            String str1 = line.substring(1, q2);
+            String str2 = line.substring(q2 + 3, line.length() - 1);
+            localizationMap.put(str1, str2);
+        }
+        loadSimulator();
+    }
+
+    public void loadSimulator() {
+        mysim = new CirSim();
+        mysim.localizationMap = localizationMap;
+        mysim.init();
+
+        Window.addResizeHandler(new ResizeHandler() {
+
+            public void onResize(ResizeEvent event) {
+                mysim.setCanvasSize();
+                mysim.setiFrameHeight();
+
             }
         });
-	    
-	    /*
-	    Window.addWindowClosingHandler(new Window.ClosingHandler() {
 
-	        public void onWindowClosing(ClosingEvent event) {
-	            event.setMessage("Are you sure?");
-	        }
-	    });
-	     */
+        /*
+         * Window.addWindowClosingHandler(new Window.ClosingHandler() {
+         * 
+         * public void onWindowClosing(ClosingEvent event) {
+         * event.setMessage("Are you sure?"); } });
+         */
 
-	  mysim.updateCircuit();
-	  
+        mysim.updateCircuit();
 
-	  
-  	}
-  
-  }
-	  
+    }
+
+}


### PR DESCRIPTION
My very start-stop-start comb-through of the project looking for easy refactoring wins... slowly continues.

The major change in this PR is that the flow of the entrypoint code has slightly changed. `loadSimulator()` is now _only_ called from `loadLocale()` to improve traceability. `processLocale()` is now a leaf function instead of a critical path function, and returns its processed data atomically so that the entrypoint class doesn't have to hold onto a refence to the locale map.

I also removed the very stale version history. I don't mean any disrespect of course. To my mind, version history should go in a dedicated file for easier access, or we should lean on the git history as a source of changes. Given that the history is quite stale I though it would be better to just exclude it. Let me know if you disagree and I'll happily revert.

cheers.