### PR TITLE
WebSocket functionality added

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/CirSim.java
+++ b/src/com/lushprojects/circuitjs1/client/CirSim.java
@@ -6323,6 +6323,8 @@ MouseOutHandler, MouseWheelHandler {
 	    $wnd.CircuitJS1 = {
 	        setSimRunning: $entry(function(run) { that.@com.lushprojects.circuitjs1.client.CirSim::setSimRunning(Z)(run); } ),
 	        getTime: $entry(function() { return that.@com.lushprojects.circuitjs1.client.CirSim::t; } ),
+	        getTimeStep: $entry(function() { return that.@com.lushprojects.circuitjs1.client.CirSim::timeStep; } ),
+	        setTimeStep: $entry(function(ts) { that.@com.lushprojects.circuitjs1.client.CirSim::timeStep = ts; } ),
 	        isRunning: $entry(function() { return that.@com.lushprojects.circuitjs1.client.CirSim::simIsRunning()(); } ),
 	        getNodeVoltage: $entry(function(n) { return that.@com.lushprojects.circuitjs1.client.CirSim::getLabeledNodeVoltage(Ljava/lang/String;)(n); } ),
 	        setExtVoltage: $entry(function(n, v) { that.@com.lushprojects.circuitjs1.client.CirSim::setExtVoltage(Ljava/lang/String;D)(n, v); } ),

--- a/src/com/lushprojects/circuitjs1/client/CirSim.java
+++ b/src/com/lushprojects/circuitjs1/client/CirSim.java
@@ -6018,28 +6018,36 @@ MouseOutHandler, MouseWheelHandler {
 	    Canvas cv = getCircuitAsCanvas(CAC_PRINT);
 	    printCanvas(cv.getCanvasElement());
 	}
-	
+
 	boolean loadedCanvas2SVG = false;
-	
-	void doExportAsSVG() {
-	    // load canvas2svg if we haven't already
-	    if (!loadedCanvas2SVG) {
-		ScriptInjector.fromUrl("canvas2svg.js").setCallback(
-			new Callback<Void,Exception>() {
-			    public void onFailure(Exception reason) {
-				Window.alert("Can't load canvas2svg.js.");
-			    }
-			    public void onSuccess(Void result) {
-				loadedCanvas2SVG = true;
-				doExportAsSVG();
-			    }
+
+	boolean initializeSVGScriptIfNecessary(final String followupAction) {
+		// load canvas2svg if we haven't already
+		if (!loadedCanvas2SVG) {
+			ScriptInjector.fromUrl("canvas2svg.js").setCallback(new Callback<Void,Exception>() {
+				public void onFailure(Exception reason) {
+					Window.alert("Can't load canvas2svg.js.");
+				}
+				public void onSuccess(Void result) {
+					loadedCanvas2SVG = true;
+					if (followupAction.equals("doExportAsSVG")) {
+						doExportAsSVG();
+					}
+				}
 			}).inject();
-		return;
-	    }
-	    dialogShowing = new ExportAsImageDialog(CAC_SVG);
-	    dialogShowing.show();
+			return false;
+		}
+		return true;
 	}
-	
+
+	void doExportAsSVG() {
+		if (!initializeSVGScriptIfNecessary("doExportAsSVG")) {
+			return;
+		}
+		dialogShowing = new ExportAsImageDialog(CAC_SVG);
+		dialogShowing.show();
+	}
+
 	static final int CAC_PRINT = 0;
 	static final int CAC_IMAGE = 1;
 	static final int CAC_SVG   = 2;
@@ -6310,7 +6318,10 @@ MouseOutHandler, MouseWheelHandler {
 	        isRunning: $entry(function() { return that.@com.lushprojects.circuitjs1.client.CirSim::simIsRunning()(); } ),
 	        getNodeVoltage: $entry(function(n) { return that.@com.lushprojects.circuitjs1.client.CirSim::getLabeledNodeVoltage(Ljava/lang/String;)(n); } ),
 	        setExtVoltage: $entry(function(n, v) { that.@com.lushprojects.circuitjs1.client.CirSim::setExtVoltage(Ljava/lang/String;D)(n, v); } ),
-	        getElements: $entry(function() { return that.@com.lushprojects.circuitjs1.client.CirSim::getJSElements()(); } )
+	        getElements: $entry(function() { return that.@com.lushprojects.circuitjs1.client.CirSim::getJSElements()(); } ),
+	        initializeSVG: $entry(function() { return that.@com.lushprojects.circuitjs1.client.CirSim::initializeSVGScriptIfNecessary(Ljava/lang/String;)(null); } ),
+	        isSVGInitialized: $entry(function() { return that.@com.lushprojects.circuitjs1.client.CirSim::loadedCanvas2SVG; } ),
+	        getCircuitAsSVG: $entry(function() { return that.@com.lushprojects.circuitjs1.client.CirSim::getCircuitAsSVG()(); } )
 	    };
 	    var hook = $wnd.oncircuitjsloaded;
 	    if (hook)

--- a/src/com/lushprojects/circuitjs1/client/CirSim.java
+++ b/src/com/lushprojects/circuitjs1/client/CirSim.java
@@ -6040,6 +6040,8 @@ MouseOutHandler, MouseWheelHandler {
 					loadedCanvas2SVG = true;
 					if (followupAction.equals("doExportAsSVG")) {
 						doExportAsSVG();
+					} else if (followupAction.equals("doExportAsSVGFromAPI")) {
+						doExportAsSVGFromAPI();
 					}
 				}
 			}).inject();
@@ -6054,6 +6056,14 @@ MouseOutHandler, MouseWheelHandler {
 		}
 		dialogShowing = new ExportAsImageDialog(CAC_SVG);
 		dialogShowing.show();
+	}
+
+	public void doExportAsSVGFromAPI() {
+		if (!initializeSVGScriptIfNecessary("doExportAsSVGFromAPI")) {
+			return;
+		}
+		String svg = getCircuitAsSVG();
+		callSVGRenderedHook(svg);
 	}
 
 	static final int CAC_PRINT = 0;
@@ -6329,9 +6339,7 @@ MouseOutHandler, MouseWheelHandler {
 	        getNodeVoltage: $entry(function(n) { return that.@com.lushprojects.circuitjs1.client.CirSim::getLabeledNodeVoltage(Ljava/lang/String;)(n); } ),
 	        setExtVoltage: $entry(function(n, v) { that.@com.lushprojects.circuitjs1.client.CirSim::setExtVoltage(Ljava/lang/String;D)(n, v); } ),
 	        getElements: $entry(function() { return that.@com.lushprojects.circuitjs1.client.CirSim::getJSElements()(); } ),
-	        initializeSVG: $entry(function() { return that.@com.lushprojects.circuitjs1.client.CirSim::initializeSVGScriptIfNecessary(Ljava/lang/String;)(null); } ),
-	        isSVGInitialized: $entry(function() { return that.@com.lushprojects.circuitjs1.client.CirSim::loadedCanvas2SVG; } ),
-	        getCircuitAsSVG: $entry(function() { return that.@com.lushprojects.circuitjs1.client.CirSim::getCircuitAsSVG()(); } ),
+	        getCircuitAsSVG: $entry(function() { return that.@com.lushprojects.circuitjs1.client.CirSim::doExportAsSVGFromAPI()(); } ),
 	        exportCircuit: $entry(function() { return that.@com.lushprojects.circuitjs1.client.CirSim::dumpCircuit()(); } ),
 	        importCircuit: $entry(function(circuit, subcircuitsOnly) { return that.@com.lushprojects.circuitjs1.client.CirSim::importCircuitFromText(Ljava/lang/String;Z)(circuit, subcircuitsOnly); })
 	    };
@@ -6359,6 +6367,12 @@ MouseOutHandler, MouseWheelHandler {
 	    	hook($wnd.CircuitJS1);
 	}-*/;
 	
+	native void callSVGRenderedHook(String svgData) /*-{
+		var hook = $wnd.CircuitJS1.onsvgrendered;
+		if (hook)
+			hook($wnd.CircuitJS1, svgData);
+	}-*/;
+
 	class UndoItem {
 	    public String dump;
 	    public double scale, transform4, transform5;

--- a/src/com/lushprojects/circuitjs1/client/CirSim.java
+++ b/src/com/lushprojects/circuitjs1/client/CirSim.java
@@ -3593,7 +3593,15 @@ MouseOutHandler, MouseWheelHandler {
     	dialogShowing = new ExportAsLocalFileDialog(dump);
     	dialogShowing.show();
     }
-    
+
+    public void importCircuitFromText(String circuitText, boolean subcircuitsOnly) {
+		int flags = subcircuitsOnly ? (CirSim.RC_SUBCIRCUITS | CirSim.RC_RETAIN) : 0;
+		if (circuitText != null) {
+			readCircuit(circuitText, flags);
+			allowSave(false);
+		}
+    }
+
     String dumpOptions() {
 	int f = (dotsCheckItem.getState()) ? 1 : 0;
 	f |= (smallGridCheckItem.getState()) ? 2 : 0;
@@ -6321,7 +6329,9 @@ MouseOutHandler, MouseWheelHandler {
 	        getElements: $entry(function() { return that.@com.lushprojects.circuitjs1.client.CirSim::getJSElements()(); } ),
 	        initializeSVG: $entry(function() { return that.@com.lushprojects.circuitjs1.client.CirSim::initializeSVGScriptIfNecessary(Ljava/lang/String;)(null); } ),
 	        isSVGInitialized: $entry(function() { return that.@com.lushprojects.circuitjs1.client.CirSim::loadedCanvas2SVG; } ),
-	        getCircuitAsSVG: $entry(function() { return that.@com.lushprojects.circuitjs1.client.CirSim::getCircuitAsSVG()(); } )
+	        getCircuitAsSVG: $entry(function() { return that.@com.lushprojects.circuitjs1.client.CirSim::getCircuitAsSVG()(); } ),
+	        exportCircuit: $entry(function() { return that.@com.lushprojects.circuitjs1.client.CirSim::dumpCircuit()(); } ),
+	        importCircuit: $entry(function(circuit, subcircuitsOnly) { return that.@com.lushprojects.circuitjs1.client.CirSim::importCircuitFromText(Ljava/lang/String;Z)(circuit, subcircuitsOnly); })
 	    };
 	    var hook = $wnd.oncircuitjsloaded;
 	    if (hook)

--- a/src/com/lushprojects/circuitjs1/client/ImportFromTextDialog.java
+++ b/src/com/lushprojects/circuitjs1/client/ImportFromTextDialog.java
@@ -62,13 +62,7 @@ TextArea textArea;
 //				s=textBox.getHTML();
 //				s=s.replace("<br>", "\r");
 				s=textArea.getText();
-				int flags = 0;
-				if (subCheck.getState())
-				    flags |= CirSim.RC_SUBCIRCUITS | CirSim.RC_RETAIN;
-				if (s!=null) {
-					sim.readCircuit(s, flags);
-					sim.allowSave(false);
-				}
+				sim.importCircuitFromText(s, subCheck.getState());
 			}
 		});
 		hp.add(cancelButton = new Button(sim.LS("Cancel")));

--- a/websocket/README.md
+++ b/websocket/README.md
@@ -68,7 +68,8 @@ that are understood, along with examples:
   - `get_elements`: List all elements of the circuit.
   - `set_ext_voltage`: Sets external voltage sources to their values.  Expects
     a `voltages` dictionary as parameter that contains name/value pairs.
-  - `get_svg`: Returns the circuit as a SVG image.
+  - `get_svg`: Returns the circuit as a SVG image. The result is returned
+    asynchronously as the "svg_rendered" event.
   - `circuit_export`: Returns the cirucit schematic.
   - `circuit_import`: Loads a circuit, provided a textual representation in the
     `circuit` element.

--- a/websocket/README.md
+++ b/websocket/README.md
@@ -20,6 +20,12 @@ Additionally, you can supply a `src=` query parameter which is the initial
 `src` attribute of the iframe. If not supplied, a sensible default is chosen
 for you so that the page always loads with a simulator.
 
+Lastly, you can specify an `autoshutoff` query parameter which tells the
+WebSocket shim that once it has once finished a WebSocket connection, it should
+automatically shut down. This is useful if your server is short-lived and may
+crash so that you don't end up a bunch of different (possibly competing)
+simulators in different browser tabs).
+
 For example, assume you're the `war/` subdirectory at `http://127.0.0.1:8123`,
 then you could have a WebSocket endpoint listening on port 4444 as
 `ws://127.0.0.1:4444/ws`. You would then open your web browser with the

--- a/websocket/README.md
+++ b/websocket/README.md
@@ -1,0 +1,109 @@
+# WebSocket interface
+CircuitJS supports reading and writing of internal circuit data already, as the
+demo in `jsinterface.html` showcases. There is also a shim that connects the
+CircuitJS JavaScript functionality by exposing it to a WebSocket interface.
+This is shown in `websocket/circuitws.html`.
+
+The CircuitJS circuit simulator connects to a given target URI using a
+WebSocket and then expects to receive JSON-formatted commands; similarly,
+JSON-formatted responses are generated. There are multiple scenarios in which
+this can be useful, but generally it allows remote controlling a browser-run
+simulation to be controlled and read out from any programming language.
+
+## Usage
+You can start by copying `circuitws.html` and `circuitws.mjs` to the `war/`
+directory, then serve it from there. You then need to invoke the URI by adding
+a `ws=` query string parameter. The code expects to find a WebSocket end point
+there and will connect to it (and reconnect if the connection is lost).
+
+Additionally, you can supply a `src=` query parameter which is the initial
+`src` attribute of the iframe. If not supplied, a sensible default is chosen
+for you so that the page always loads with a simulator.
+
+For example, assume you're the `war/` subdirectory at `http://127.0.0.1:8123`,
+then you could have a WebSocket endpoint listening on port 4444 as
+`ws://127.0.0.1:4444/ws`. You would then open your web browser with the
+following URI:
+
+`http://127.0.0.1:8123/circuitws.html?ws=ws%3A%2F%2F127.0.0.1%3A4444%2Fws`
+
+The simulator will start up and immediately connect to
+`ws://127.0.0.1:4444/ws`, from which it expects commands.
+
+## Commands
+The command structure is always as follows:
+
+```json
+{
+	"cmd":		"cmdname",
+	"msgid":	1234,
+	"foo":		"bar"
+}
+```
+
+Every command needs to have the `cmd` key set in the dictionary. The `msgid` is
+optional, but will be reflected in the response so that it is easy to correlate
+requests with their corresponding responses, even if responses are sent
+out-of-order.
+
+Additional parameters may be required for some commands. These are commands
+that are understood, along with examples:
+
+  - `status`: Query the state of the simulator.
+  - `set_running`: Start or stop the simulator (depending on the boolean
+    argument in `state`)
+  - `reload`: Reload the iframe. Supports an additional `args` command, which
+    is a dictionary that contains the query parameters for the new iframe. The
+    source cannot be modified.
+  - `set_timestamp`: Sets the timestamp to the double value in the `timestep`
+    key.
+  - `get_node_voltage`: Query the node voltage of nodes. Expects a list of
+    named nodes in the `nodes` element.
+  - `get_elements`: List all elements of the circuit.
+  - `set_ext_voltage`: Sets external voltage sources to their values.  Expects
+    a `voltages` dictionary as parameter that contains name/value pairs.
+  - `get_svg`: Returns the circuit as a SVG image.
+  - `circuit_export`: Returns the cirucit schematic.
+  - `circuit_import`: Loads a circuit, provided a textual representation in the
+    `circuit` element.
+
+## Example
+If you have Python3.10+ and the module aiohttp installed, you can easily try
+the example. It expects the `war` directory to be served at port 8123 and will
+open a websocket listening port on 8080:
+
+```
+$ python3 circuitws_server.py
+Point your browser to: http://127.0.0.1:8123/circuitws.html?ws=ws%3A%2F%2F127.0.0.1%3A8080%2Fws
+======== Running on http://127.0.0.1:8080 ========
+(Press CTRL+C to quit)
+```
+
+Then, Python will wait for the user to open the URL. Once that happens, a CLI console starts:
+
+```
+Websocket connected.
+Cmd:
+```
+
+You can now enter commands, such as `?`, `start`, `stop`, `svg`, etc. If you
+type `help` you'll get an overview of what is supported.
+
+```
+Cmd: ?
+{'type': 'response', 'status': 'ok', 'cmd': 'status', 'msgid': 1, 'data': {'running': True, 'time': 1.0127750000024012, 'timestep': 5e-06}}
+Cmd: stop
+{'type': 'response', 'status': 'ok', 'cmd': 'set_running', 'msgid': 2}
+Cmd: ?
+{'type': 'response', 'status': 'ok', 'cmd': 'status', 'msgid': 3, 'data': {'running': False, 'time': 1.0562150000026858, 'timestep': 5e-06}}
+Cmd: ?
+{'type': 'response', 'status': 'ok', 'cmd': 'status', 'msgid': 4, 'data': {'running': False, 'time': 1.0562150000026858, 'timestep': 5e-06}}
+Cmd: start
+{'type': 'response', 'status': 'ok', 'cmd': 'set_running', 'msgid': 5}
+Cmd: ?
+{'type': 'response', 'status': 'ok', 'cmd': 'status', 'msgid': 6, 'data': {'running': True, 'time': 1.0699000000027754, 'timestep': 5e-06}}
+Cmd: sev1
+{'type': 'response', 'status': 'ok', 'cmd': 'set_ext_voltage', 'msgid': 7}
+Cmd: help
+Not understood. Commands: ?, start, stop, setts, gnv, list, sev1, sev2, svg, export, import, q
+```

--- a/websocket/circuitws.html
+++ b/websocket/circuitws.html
@@ -12,6 +12,7 @@
 			const iframe = document.querySelector("#circuitFrame");
 			const circuitws = new CircuitWS(iframe);
 			const search_params = new URLSearchParams(window.location.search);
+			console.log(search_params.get("src"));
 			if (search_params.has("src")) {
 				iframe.src = search_params.get("src");
 			} else {

--- a/websocket/circuitws.html
+++ b/websocket/circuitws.html
@@ -5,13 +5,19 @@
 		<title>CircuitJS websockets automation</title>
 	</head>
 	<body>
-		<iframe id="circuitFrame" width=800 height=550 src="circuitjs.html?startCircuit=jsinterface.txt"></iframe>
+		<iframe id="circuitFrame" width=800 height=550></iframe>
 
 		<script type="module">
 			import {CircuitWS} from "./circuitws.mjs";
 			const iframe = document.querySelector("#circuitFrame");
 			const circuitws = new CircuitWS(iframe);
-			circuitws.initialize_parameters(new URLSearchParams(window.location.search));
+			const search_params = new URLSearchParams(window.location.search);
+			if (search_params.has("src")) {
+				iframe.src = search_params.get("src");
+			} else {
+				iframe.src = "circuitjs.html?startCircuit=jsinterface.txt";
+			}
+			circuitws.initialize_parameters(search_params);
 		</script>
 	</body>
 </html>

--- a/websocket/circuitws.html
+++ b/websocket/circuitws.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html>
+	<head>
+		<meta name="viewport" content="width=820">
+		<title>CircuitJS websockets automation</title>
+	</head>
+	<body>
+		<iframe id="circuitFrame" width=800 height=550 src="circuitjs.html?startCircuit=jsinterface.txt"></iframe>
+
+		<script type="module">
+			import {CircuitWS} from "./circuitws.mjs";
+			const iframe = document.querySelector("#circuitFrame");
+			const circuitws = new CircuitWS(iframe);
+			circuitws.initialize_parameters(new URLSearchParams(window.location.search));
+		</script>
+	</body>
+</html>

--- a/websocket/circuitws.html
+++ b/websocket/circuitws.html
@@ -12,11 +12,10 @@
 			const iframe = document.querySelector("#circuitFrame");
 			const circuitws = new CircuitWS(iframe);
 			const search_params = new URLSearchParams(window.location.search);
-			console.log(search_params.get("src"));
 			if (search_params.has("src")) {
-				iframe.src = search_params.get("src");
+				circuitws.reload_circuitjs(search_params.get("src"));
 			} else {
-				iframe.src = "circuitjs.html?startCircuit=jsinterface.txt";
+				circuitws.reload_circuitjs("circuitjs.html?startCircuit=jsinterface.txt");
 			}
 			circuitws.initialize_parameters(search_params);
 		</script>

--- a/websocket/circuitws.mjs
+++ b/websocket/circuitws.mjs
@@ -8,9 +8,11 @@ export class CircuitWS {
 
 	connect(ws_uri) {
 		this._ws_uri = ws_uri;
-		this._ws = new WebSocket(ws_uri);
-		this._ws.onmessage = (event) => this._ws_message(event);
-		this._ws.onclose = (event) => this._ws_close(event);
+		if (ws_uri != null) {
+			this._ws = new WebSocket(ws_uri);
+			this._ws.onmessage = (event) => this._ws_message(event);
+			this._ws.onclose = (event) => this._ws_close(event);
+		}
 	}
 
 	initialize_parameters(query_params) {
@@ -121,6 +123,10 @@ export class CircuitWS {
 				return
 			}
 			response.data = this.sim.getCircuitAsSVG();
+		} else if (msg.cmd == "shutdown") {
+			this.connect(null);
+			this._ws.close();
+			this._iframe.src = "about:blank";
 		} else {
 			this._respond_error("unknown_cmd", "Unknown command: " + msg.cmd)
 			return;

--- a/websocket/circuitws.mjs
+++ b/websocket/circuitws.mjs
@@ -63,7 +63,11 @@ export class CircuitWS {
 		if (msg.hasOwnProperty("msgid")) {
 			response.msgid = msg.msgid;
 		}
-		if (msg.cmd == "status") {
+		if (msg.cmd == "reload") {
+			const url = new URL(this._iframe.src);
+			url.search = "?" + (new URLSearchParams(msg.args).toString());
+			this._iframe.src = url.toString();
+		} else if (msg.cmd == "status") {
 			response.data = {
 				"running":	this.sim.isRunning(),
 				"time":		this.sim.getTime(),

--- a/websocket/circuitws.mjs
+++ b/websocket/circuitws.mjs
@@ -67,9 +67,16 @@ export class CircuitWS {
 			response.data = {
 				"running":	this.sim.isRunning(),
 				"time":		this.sim.getTime(),
+				"timestep":	this.sim.getTimeStep(),
 			};
 		} else if (msg.cmd == "set_running") {
 			this.sim.setSimRunning(msg.state);
+		} else if (msg.cmd == "set_timestep") {
+			if (!msg.hasOwnProperty("timestep")) {
+				this._respond_error("no_timestep_in_request", "No 'timestep' element found in JSON request.")
+				return;
+			}
+			this.sim.setTimeStep(msg.timestep);
 		} else if (msg.cmd == "get_node_voltage") {
 			response.data = { };
 			for (let node_name of msg.nodes) {

--- a/websocket/circuitws.mjs
+++ b/websocket/circuitws.mjs
@@ -1,0 +1,90 @@
+export class CircuitWS {
+	constructor(iframe) {
+		this._iframe = iframe;
+		this._ws_uri = null;
+		this._ws = null;
+	}
+
+	connect(ws_uri) {
+		this._ws_uri = ws_uri;
+		this._ws = new WebSocket(ws_uri);
+		this._ws.onmessage = (event) => this._ws_message(event);
+		this._ws.onclose = (event) => this._ws_close(event);
+	}
+
+	initialize_parameters(query_params) {
+		if (query_params.has("ws")) {
+			this.connect(query_params.get("ws"));
+		}
+	}
+
+	_respond(msg) {
+		this._ws.send(JSON.stringify(msg));
+	}
+
+	_respond_error(error_code, error_text) {
+		this._respond({ "status": "error", "code": error_code, "text": error_text })
+	}
+
+	_ws_message(event) {
+		const msg = JSON.parse(event.data);
+		if (!msg.hasOwnProperty("cmd")) {
+			this._respond_error("no_cmd_in_request", "No 'cmd' element found in JSON request.")
+			return;
+		}
+
+		if (!this.sim) {
+			this._respond_error("no_sim_running", "No simulation running (iframe not loaded yet?).")
+			return;
+		}
+
+		let response = {
+			"status": "ok",
+			"cmd": msg.cmd,
+		};
+		if (msg.hasOwnProperty("msgid")) {
+			response.msgid = msg.msgid;
+		}
+		if (msg.cmd == "status") {
+			response.data = {
+				"running":	this.sim.isRunning(),
+				"time":		this.sim.getTime(),
+			};
+		} else if (msg.cmd == "set_running") {
+			this.sim.setSimRunning(msg.state);
+		} else if (msg.cmd == "get_node_voltage") {
+			response.data = { };
+			for (let node_name of msg.nodes) {
+				response.data[node_name] = this.sim.getNodeVoltage(node_name);
+			}
+		} else if (msg.cmd == "get_elements") {
+			response.data = [ ];
+			for (let element of this.sim.getElements()) {
+				response.data.push({
+					"type":			element.getType(),
+					"post_count":	element.getPostCount(),
+					"info":			element.getInfo(),
+				});
+			}
+		} else if (msg.cmd == "set_ext_voltage") {
+			for (const [name, value] of Object.entries(msg.voltages)) {
+				this.sim.setExtVoltage(name, value);
+			}
+		} else {
+			this._respond_error("unknown_cmd", "Unknown command: " + msg.cmd)
+			return;
+		}
+		this._respond(response);
+	}
+
+	_ws_close(event) {
+		/* Attempt to reconnect after a while */
+		setTimeout(() => {
+			this.connect(this._ws_uri);
+		}, 1000);
+	}
+
+	get sim() {
+		return this._iframe.contentWindow.CircuitJS1;
+	}
+}

--- a/websocket/circuitws.mjs
+++ b/websocket/circuitws.mjs
@@ -88,6 +88,15 @@ export class CircuitWS {
 			for (const [name, value] of Object.entries(msg.voltages)) {
 				this.sim.setExtVoltage(name, value);
 			}
+		} else if (msg.cmd == "circuit_export") {
+			response.data = this.sim.exportCircuit();
+		} else if (msg.cmd == "circuit_import") {
+			if (!msg.hasOwnProperty("circuit")) {
+				this._respond_error("no_circuit_in_request", "No 'circuit' element found in JSON request.")
+				return;
+			}
+			const subcircuits_only = !!msg.subcircuits_only;
+			this.sim.importCircuit(msg.circuit, subcircuits_only);
 		} else if (msg.cmd == "get_svg") {
 			const initialized = await this._initialize_svg();
 			if (!initialized) {

--- a/websocket/circuitws_server.py
+++ b/websocket/circuitws_server.py
@@ -33,13 +33,15 @@ async def websocket_handler(request):
 				msg = { "cmd": "set_ext_voltage", "voltages": { "extsin": 1 } }
 			case "sev2":
 				msg = { "cmd": "set_ext_voltage", "voltages": { "extsin": 2 } }
+			case "svg":
+				msg = { "cmd": "get_svg" }
 			case "q":
 				sys.exit(0)
 				break
 			case "":
 				continue
 			case _:
-				print("Not understood. Commands: ?, start, stop, gnv, list, sev1, sev2, q")
+				print("Not understood. Commands: ?, start, stop, gnv, list, sev1, sev2, svg, q")
 				continue
 
 		await ws.send_json(msg)

--- a/websocket/circuitws_server.py
+++ b/websocket/circuitws_server.py
@@ -34,6 +34,8 @@ async def websocket_handler(request):
 				msg = { "cmd": "set_running", "state": True }
 			case "stop":
 				msg = { "cmd": "set_running", "state": False }
+			case "reload":
+				msg = { "cmd": "reload", "args": { "IECGates": False, "whiteBackground": True } }
 			case "setts":
 				msg = { "cmd": "set_timestep", "timestep": 1e-3 }
 			case "gnv":

--- a/websocket/circuitws_server.py
+++ b/websocket/circuitws_server.py
@@ -19,7 +19,9 @@ w 240 256 240 272 0
 z 208 224 272 224 2 default-zener
 """
 
+
 async def websocket_handler(request):
+	msg_id = 0
 	print("Websocket connected.")
 	ws = aiohttp.web.WebSocketResponse()
 	await ws.prepare(request)
@@ -61,8 +63,13 @@ async def websocket_handler(request):
 				print("Not understood. Commands: ?, start, stop, setts, gnv, list, sev1, sev2, svg, export, import, q")
 				continue
 
+		msg_id += 1
+		msg["msgid"] = msg_id
 		await ws.send_json(msg)
-		response = await ws.receive_json()
+		while True:
+			response = await ws.receive_json()
+			if response.get("msgid") == msg_id:
+				break
 		print(response)
 
 	return ws

--- a/websocket/circuitws_server.py
+++ b/websocket/circuitws_server.py
@@ -1,0 +1,65 @@
+import asyncio
+import os
+import urllib.parse
+import aiohttp.web
+import sys
+
+config = {
+	"host":				"127.0.0.1",
+	"port":				8080,
+	"circuitws_uri":	"http://127.0.0.1:8123/circuitws.html",
+}
+
+async def websocket_handler(request):
+	print("Websocket connected.")
+	ws = aiohttp.web.WebSocketResponse()
+	await ws.prepare(request)
+
+	while True:
+		cmd = input("Cmd: ")
+
+		match cmd.lower():
+			case "?":
+				msg = { "cmd": "status" }
+			case "start":
+				msg = { "cmd": "set_running", "state": True }
+			case "stop":
+				msg = { "cmd": "set_running", "state": False }
+			case "gnv":
+				msg = { "cmd": "get_node_voltage", "nodes": [ "D7", "D6" ] }
+			case "list":
+				msg = { "cmd": "get_elements" }
+			case "sev1":
+				msg = { "cmd": "set_ext_voltage", "voltages": { "extsin": 1 } }
+			case "sev2":
+				msg = { "cmd": "set_ext_voltage", "voltages": { "extsin": 2 } }
+			case "q":
+				sys.exit(0)
+				break
+			case "":
+				continue
+			case _:
+				print("Not understood. Commands: ?, start, stop, gnv, list, sev1, sev2, q")
+				continue
+
+		await ws.send_json(msg)
+		response = await ws.receive_json()
+		print(response)
+
+	return ws
+
+
+def main():
+	my_uri = f"ws://{config['host']}:{config['port']}/ws"
+	query = {
+		"ws":	my_uri,
+	}
+	print(f"Point your browser to: {config['circuitws_uri']}?{urllib.parse.urlencode(query)}")
+
+	app = aiohttp.web.Application()
+	app.router.add_route("GET", "/ws", websocket_handler)
+	aiohttp.web.run_app(app, host = config["host"], port = config["port"])
+
+
+if __name__ == "__main__":
+	main()

--- a/websocket/circuitws_server.py
+++ b/websocket/circuitws_server.py
@@ -52,6 +52,7 @@ async def websocket_handler(request):
 				msg = { "cmd": "set_ext_voltage", "voltages": { "extsin": 2 } }
 			case "svg":
 				msg = { "cmd": "get_svg" }
+				wait_for_event = "svg_rendered"
 			case "export":
 				msg = { "cmd": "circuit_export" }
 			case "import":
@@ -74,6 +75,7 @@ async def websocket_handler(request):
 				break
 			elif (wait_for_event is not None) and (response["type"] == "event") and (response["code"] == wait_for_event):
 				break
+			print("Ignored:", response)
 		print(response)
 
 	return ws

--- a/websocket/circuitws_server.py
+++ b/websocket/circuitws_server.py
@@ -10,6 +10,15 @@ config = {
 	"circuitws_uri":	"http://127.0.0.1:8123/circuitws.html",
 }
 
+demo_circuit = """\
+$ 1 0.000005 10.20027730826997 50 5 50 5e-11
+w 192 272 208 304 0
+w 208 304 272 304 0
+w 272 304 288 272 0
+w 240 256 240 272 0
+z 208 224 272 224 2 default-zener
+"""
+
 async def websocket_handler(request):
 	print("Websocket connected.")
 	ws = aiohttp.web.WebSocketResponse()
@@ -35,13 +44,17 @@ async def websocket_handler(request):
 				msg = { "cmd": "set_ext_voltage", "voltages": { "extsin": 2 } }
 			case "svg":
 				msg = { "cmd": "get_svg" }
+			case "export":
+				msg = { "cmd": "circuit_export" }
+			case "import":
+				msg = { "cmd": "circuit_import", "circuit": demo_circuit }
 			case "q":
 				sys.exit(0)
 				break
 			case "":
 				continue
 			case _:
-				print("Not understood. Commands: ?, start, stop, gnv, list, sev1, sev2, svg, q")
+				print("Not understood. Commands: ?, start, stop, gnv, list, sev1, sev2, svg, export, import, q")
 				continue
 
 		await ws.send_json(msg)

--- a/websocket/circuitws_server.py
+++ b/websocket/circuitws_server.py
@@ -34,6 +34,8 @@ async def websocket_handler(request):
 				msg = { "cmd": "set_running", "state": True }
 			case "stop":
 				msg = { "cmd": "set_running", "state": False }
+			case "setts":
+				msg = { "cmd": "set_timestep", "timestep": 1e-3 }
 			case "gnv":
 				msg = { "cmd": "get_node_voltage", "nodes": [ "D7", "D6" ] }
 			case "list":
@@ -54,7 +56,7 @@ async def websocket_handler(request):
 			case "":
 				continue
 			case _:
-				print("Not understood. Commands: ?, start, stop, gnv, list, sev1, sev2, svg, export, import, q")
+				print("Not understood. Commands: ?, start, stop, setts, gnv, list, sev1, sev2, svg, export, import, q")
 				continue
 
 		await ws.send_json(msg)


### PR DESCRIPTION
This is the WebSocket interface discussed in https://github.com/pfalstad/circuitjs1/discussions/27

I've made some more improvements to check that it actually works as intended in a real-world scenario. Namely, this code uses the WS interface: https://github.com/johndoe31415/pyradium/blob/master/pyradium/modify/CircuitJSRenderImages.py

I use it to automatically export all circuits contained within my presentation, pass them automatically to the simulator running in a browser, exporting the SVG and writing that to individual files. It works nicely. There are currently two issues with the code:

- ~~The SVG export, as discussed, works initally using an ugly workaround (`isSVGInitialized` etc). I've looked at how to implement that with a callback myself, as you had suggested, but I gave up :-) The API on the WS side is not affected by this (it's only internally between CircuitJS1 and the WebSocket shim).~~ Fixed.
- ~~When reloading the iframe, there's a nasty property: We already have a reference to the simulator (`iframe.contentWindow.CircuitJS1`) but, if we're very soon after the reload completes then the application reference is there but it's not yet fully initialized. I currently "fix" this using the ugly hack of sleeping 500ms after I've receved the event that the simulator is up (then it is fully initialized in all my cases). But that's not the right way to do it. Unfortunately I cannot figure out how to determine reliably if the simulator is fully up and running. Possibly another calback could be added to make this a little bit cleaner.~~ Fixed.

All commits have been cleaned up to provide individual and separate functionality so it's not just one big chunk.