### PR TITLE
Bugfix: Exception when translating empty string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@ war/circuitjs1/circuits/
 war/e-*.html
 war/WEB-INF/
 
+# GWT command line tools
+codeserver.log
+webserver.log
+
 # Windows image file caches
 Thumbs.db
 ehthumbs.db

--- a/gwt.sh
+++ b/gwt.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+set -o errexit -o nounset
+
+SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+WORK_DIR="../workdir"
+SDK_DIR=".."
+GWT_VERSION="2.10.0"
+GWT="$SDK_DIR/gwt-$GWT_VERSION"
+
+compile() {
+    ant build
+}
+
+setup() {
+    # Install Java if no java compiler is present
+    if ! which javac > /dev/null 2>&1; then
+        echo "Installing packages may need your sudo password."
+        set -x
+        sudo apt install openjdk-8-jdk-headless
+        set +x
+    fi
+
+    if ! [[ -d "$SDK_DIR" ]]; then
+        mkdir -p "$SDK_DIR"
+        cd "$SDK_DIR"
+        wget "https://github.com/gwtproject/gwt/releases/download/$GWT_VERSION/gwt-$GWT_VERSION.zip"
+        unzip "gwt-$GWT_VERSION.zip"
+        rm "gwt-$GWT_VERSION.zip"
+        set +x
+    fi
+
+    if ! [[ -e build.xml ]]; then
+        chmod +x "$GWT/webAppCreator"
+        "$GWT/webAppCreator" -out ../tempProject com.lushprojects.circuitjs1.circuitjs1
+        cp ../tempProject/build.xml .
+        rm -rf ../tempProject
+    fi
+}
+
+codeserver() {
+    mkdir -p war
+    java -classpath "src:$GWT/gwt-codeserver.jar:$GWT/gwt-dev.jar:$GWT/gwt-user.jar" \
+        com.google.gwt.dev.codeserver.CodeServer \
+        -launcherDir war \
+        com.lushprojects.circuitjs1.circuitjs1
+}
+
+webserver() {
+    sourcedir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+    #webroot="workdir/com.lushprojects.circuitjs1.circuitjs1/compile-1/war"
+    webroot="war"
+
+    #cp -r "$sourcedir/war/"*.html "$webroot"
+    cd $webroot
+    python -m http.server
+}
+
+start() {
+    webserver >"webserver.log" 2>&1 &
+    PID=$!
+    codeserver | tee "codeserver.log"
+    kill -INT "$PID"
+}
+
+
+for func in $(compgen -A function); do
+    if [[ $func == "$1" ]]; then
+        shift
+        $func "$@"
+        exit $?
+    fi
+done
+
+echo "Unknown command '$1'. Try one of the following:"
+compgen -A function
+exit 1

--- a/src/com/lushprojects/circuitjs1/client/ChipElm.java
+++ b/src/com/lushprojects/circuitjs1/client/ChipElm.java
@@ -104,6 +104,8 @@ abstract class ChipElm extends CircuitElm {
 		    g.setColor(lightGrayColor);
 		    drawThickCircle(g, p.bubbleX, p.bubbleY, 3);
 		}
+		if (p.clockPointsX != null)
+		    g.drawPolyline(p.clockPointsX, p.clockPointsY, 3);
 		g.setColor(p.selected ? selectColor : whiteColor);
 		int fsz = 10*csize;
 		double availSpace = cspc*2-8;
@@ -130,9 +132,9 @@ abstract class ChipElm extends CircuitElm {
 			tx = p.textloc.x+(cspc-5)-sw;
 		    else
 			tx = p.textloc.x-sw/2;
-		    g.drawString(p.text, tx, p.textloc.y+asc/2);
+		    g.drawString(p.text, tx, p.textloc.y+asc/3);
 		    if (p.lineOver) {
-			int ya = p.textloc.y-asc/2;
+			int ya = p.textloc.y-asc+asc/3;
 			g.drawLine(tx, ya, tx+sw, ya);
 		    }
 		    break;
@@ -140,13 +142,10 @@ abstract class ChipElm extends CircuitElm {
 	    }
 	    g.setColor(needsHighlight() ? selectColor : lightGrayColor);
 	    drawThickPolygon(g, rectPointsX, rectPointsY, 4);
-	    if (clockPointsX != null)
-		g.drawPolyline(clockPointsX, clockPointsY, 3);
 	    drawPosts(g);
 	    g.restore();
 	}
 	int rectPointsX[], rectPointsY[];
-	int clockPointsX[], clockPointsY[];
 	Pin pins[];
 	int sizeX, sizeY, flippedSizeX, flippedSizeY;
 	boolean lastClock;
@@ -161,7 +160,6 @@ abstract class ChipElm extends CircuitElm {
 	    setPoints();
 	}
 	void setPoints() {
-	    clockPointsX = null;
 	    if (x2-x > sizeX*cspc2 && this == sim.dragElm)
 		setSize(2);
 	    int x0 = x+cspc2; int y0 = y;
@@ -468,6 +466,7 @@ abstract class ChipElm extends CircuitElm {
 	    String text;
 	    boolean lineOver, bubble, clock, output, value, state, selected;
 	    double curcount, current;
+            int clockPointsX[], clockPointsY[];
 	    void setPoint(int px, int py, int dx, int dy, int dax, int day, int sx, int sy) {
 		if ((flags & FLAG_FLIP_X) != 0) {
 		    dx = -dx;
@@ -491,17 +490,30 @@ abstract class ChipElm extends CircuitElm {
 		    bubbleY = ya+day*10*csize;
 		}
 		if (clock) {
-		    clockPointsX = new int[3];
-		    clockPointsY = new int[3];
+		    if (clockPointsX == null) {
+			clockPointsX = new int[3];
+			clockPointsY = new int[3];
+		    }
 		    clockPointsX[0] = xa+dax*cspc-dx*cspc/2;
 		    clockPointsY[0] = ya+day*cspc-dy*cspc/2;
 		    clockPointsX[1] = xa;
 		    clockPointsY[1] = ya;
 		    clockPointsX[2] = xa+dax*cspc+dx*cspc/2;
 		    clockPointsY[2] = ya+day*cspc+dy*cspc/2;
+		    if (text.length() > 0) {
+			// See for example http://127.0.0.1:8000/circuitjs.html?ctz=CQAgjCAMB0l3BWcMBMcUHYMGZIA4UA2ATmIxAUgpABZsKBTAWjDACgAncDQkPKlDSr8oySGzTkwPPlTAo8s2iADCAGQDSALgCSAOQBqWle0khBwgUJDYUy9dv1GVKCZHIXwNGubyKw3vaauobG2G5SMgE+0rxgxHY+DiHONJzcvCKxXj5y8OnZ0ebWRXlw6Z5FniJl4kA
+			clockPointsX[1] += dax*cspc/2;
+			clockPointsY[1] += day*cspc/2;
+			textloc.x -= dax*cspc/2;
+			textloc.y -= day*cspc/4;
+		    }
+		}
+		else {
+		    clockPointsX = null;
+		    clockPointsY = null;
 		}
 	    }
-	    
+
 	    // convert position, side to a grid position (0=top left) so we can detect overlaps
 	    int toGrid(int p, int s) {
 		if (s == SIDE_N)
@@ -527,6 +539,22 @@ abstract class ChipElm extends CircuitElm {
 		    text = text.substring(1);
 		    lineOver = true;
 		}
+		else if (text.startsWith("#")) {
+		    text = text.substring(1);
+		    bubble = true;
+		}
+
+		String result = text.replaceAll("CLK:", "");
+		if (result.length() != text.length()) {
+		    clock = true;
+		    text = result;
+		}
+		result = text.replaceAll("INV:", "");
+		if (result.length() != text.length()) {
+		    bubble = true;
+		    text = result;
+		}
+
 		if (text.compareToIgnoreCase("clk") == 0) {
 		    text = "";
 		    clock = true;

--- a/src/com/lushprojects/circuitjs1/client/CirSim.java
+++ b/src/com/lushprojects/circuitjs1/client/CirSim.java
@@ -26,6 +26,7 @@ package com.lushprojects.circuitjs1.client;
 
 import java.util.Vector;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
@@ -6152,6 +6153,10 @@ MouseOutHandler, MouseWheelHandler {
 	    CustomLogicModel.clearDumpedFlags();
 	    DiodeModel.clearDumpedFlags();
 	    TransistorModel.clearDumpedFlags();
+            Vector<LabeledNodeElm> sideLabels[] = new Vector[] {
+                new Vector<LabeledNodeElm>(), new Vector<LabeledNodeElm>(),
+                new Vector<LabeledNodeElm>(), new Vector<LabeledNodeElm>()
+            };
 	    Vector<ExtListEntry> extList = new Vector<ExtListEntry>();
 	    boolean sel = isSelection();
 	    
@@ -6173,13 +6178,30 @@ MouseOutHandler, MouseWheelHandler {
 		    if (extnodes[ce.getNode(0)])
 			continue;
 		    
+                    int side = ChipElm.SIDE_W;
+                    if (Math.abs(ce.dx) >= Math.abs(ce.dy) && ce.dx > 0) side = ChipElm.SIDE_E;
+                    if (Math.abs(ce.dx) <= Math.abs(ce.dy) && ce.dy < 0) side = ChipElm.SIDE_N;
+                    if (Math.abs(ce.dx) <= Math.abs(ce.dy) && ce.dy > 0) side = ChipElm.SIDE_S;
+                    
 		    // create ext list entry for external nodes
-		    ExtListEntry ent = new ExtListEntry(label, ce.getNode(0));
-		    extList.add(ent);
+                    sideLabels[side].add(lne);
 		    extnodes[ce.getNode(0)] = true;
 		}
 	    }
 	    
+            Collections.sort(sideLabels[ChipElm.SIDE_W], (LabeledNodeElm a, LabeledNodeElm b) -> Integer.signum(a.y - b.y));
+            Collections.sort(sideLabels[ChipElm.SIDE_E], (LabeledNodeElm a, LabeledNodeElm b) -> Integer.signum(a.y - b.y));
+            Collections.sort(sideLabels[ChipElm.SIDE_N], (LabeledNodeElm a, LabeledNodeElm b) -> Integer.signum(a.x - b.x));
+            Collections.sort(sideLabels[ChipElm.SIDE_S], (LabeledNodeElm a, LabeledNodeElm b) -> Integer.signum(a.x - b.x));
+
+            for (int side = 0; side < sideLabels.length; side++) {
+                for (int pos = 0; pos < sideLabels[side].size(); pos++) {
+                    LabeledNodeElm lne = sideLabels[side].get(pos);
+                    ExtListEntry ent = new ExtListEntry(lne.text, lne.getNode(0), pos, side);
+                    extList.add(ent);
+                }
+            }
+
 	    // output all the elements
 	    for (i = 0; i != elmList.size(); i++) {
 		CircuitElm ce = getElm(i);

--- a/src/com/lushprojects/circuitjs1/client/CirSim.java
+++ b/src/com/lushprojects/circuitjs1/client/CirSim.java
@@ -3288,7 +3288,7 @@ MouseOutHandler, MouseWheelHandler {
     	    needAnalyze();
 	}
     	
-    	if (item.substring(0,10)=="addToScope" && menuElm != null) {
+    	if (item.startsWith("addToScope") && menuElm != null) {
     	    int n;
     	    n = Integer.parseInt(item.substring(10));
     	    if (n < scopeCount + countScopeElms()) {

--- a/src/com/lushprojects/circuitjs1/client/EditCompositeModelDialog.java
+++ b/src/com/lushprojects/circuitjs1/client/EditCompositeModelDialog.java
@@ -75,21 +75,34 @@ public class EditCompositeModelDialog extends Dialog implements MouseDownHandler
             });
             int i;
             int postCount = model.extList.size();
-
-            model.sizeX = 2;
-            model.sizeY = (postCount+1)/2;
+            int sideCounts[] = new int[] { 0, 0, 0, 0 };
             for (i = 0; i != postCount; i++) {
-        	boolean left = i < model.sizeY;
-        	int side = (left) ? ChipElm.SIDE_W : ChipElm.SIDE_E;
         	ExtListEntry pin = model.extList.get(i);
-        	pin.pos = left ? i : i-model.sizeY;
-        	pin.side = side;
+                sideCounts[pin.side] += 1;
+
         	if (nodeSet.contains(pin.node)) {
         	    Window.alert(Locale.LS("Can't have two input/output nodes connected!"));
         	    return false;
         	}
         	nodeSet.add(pin.node);
             }
+
+            int xOffsetLeft = (sideCounts[ChipElm.SIDE_W] > 0) ? 1 : 0;
+            int xOffsetRight = (sideCounts[ChipElm.SIDE_E] > 0) ? 1 : 0;
+            for (i = 0; i != postCount; i++) {
+                ExtListEntry pin = model.extList.get(i);
+                if (pin.side == ChipElm.SIDE_N || pin.side == ChipElm.SIDE_S) {
+                    pin.pos += xOffsetLeft;
+                }
+            }
+
+            int minHeight = (sideCounts[ChipElm.SIDE_N] > 0 && sideCounts[ChipElm.SIDE_S] > 0) ? 2 : 1;
+            int minWidth = 2;
+            int pinsNS = Math.max(sideCounts[ChipElm.SIDE_N], sideCounts[ChipElm.SIDE_S]);
+            int pinsWE = Math.max(sideCounts[ChipElm.SIDE_W], sideCounts[ChipElm.SIDE_E]);
+            model.sizeX = Math.max(minWidth, pinsNS + xOffsetLeft + xOffsetRight);
+            model.sizeY = Math.max(minHeight, pinsWE);
+
             model.modelCircuit = CirSim.theSim.dumpCircuit();
             return true;
         }

--- a/src/com/lushprojects/circuitjs1/client/util/Locale.java
+++ b/src/com/lushprojects/circuitjs1/client/util/Locale.java
@@ -35,6 +35,10 @@ public class Locale {
         if (s == null)
             return null;
 
+        if (s.length() == 0) { // empty strings trip up the 'if (ix != s.length() - 1)' below
+            return s;
+        }
+
         String sm = localizationMap.get(s);
         if (sm != null)
             return sm;


### PR DESCRIPTION
When debugging this project using GWT 2.10.0 "Super Dev Mode" from the command line, it is not possible to open the `EditDialog` for a `LabeledNodeElm`. Instead a cryptic exception is thrown with the following message (the stack trace is unreadable):

    Uncaught Error: com.google.gwt.event.shared.UmbrellaException: Exception caught: fromIndex: 0, toIndex: -1, length: 0

The error comes from the line `s = s.substring(0, ix);` in Locale.java, which evaluates to `s.substring(0, -1)` when the function is called with an empty string. Apparently GWT 2.10.0 does not like this. I thought about rewriting the `indexOf` check to use `endsWith` instead, which would correctly handle empty strings. But since "explicit is better than implicit" I added a special case check for empty strings instead.