### PR TITLE
Feature: Initialize subcircuit pin positions from schematic

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/CirSim.java
+++ b/src/com/lushprojects/circuitjs1/client/CirSim.java
@@ -26,6 +26,7 @@ package com.lushprojects.circuitjs1.client;
 
 import java.util.Vector;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
@@ -6152,6 +6153,10 @@ MouseOutHandler, MouseWheelHandler {
 	    CustomLogicModel.clearDumpedFlags();
 	    DiodeModel.clearDumpedFlags();
 	    TransistorModel.clearDumpedFlags();
+            Vector<LabeledNodeElm> sideLabels[] = new Vector[] {
+                new Vector<LabeledNodeElm>(), new Vector<LabeledNodeElm>(),
+                new Vector<LabeledNodeElm>(), new Vector<LabeledNodeElm>()
+            };
 	    Vector<ExtListEntry> extList = new Vector<ExtListEntry>();
 	    boolean sel = isSelection();
 	    
@@ -6173,13 +6178,30 @@ MouseOutHandler, MouseWheelHandler {
 		    if (extnodes[ce.getNode(0)])
 			continue;
 		    
+                    int side = ChipElm.SIDE_W;
+                    if (Math.abs(ce.dx) >= Math.abs(ce.dy) && ce.dx > 0) side = ChipElm.SIDE_E;
+                    if (Math.abs(ce.dx) <= Math.abs(ce.dy) && ce.dy < 0) side = ChipElm.SIDE_N;
+                    if (Math.abs(ce.dx) <= Math.abs(ce.dy) && ce.dy > 0) side = ChipElm.SIDE_S;
+                    
 		    // create ext list entry for external nodes
-		    ExtListEntry ent = new ExtListEntry(label, ce.getNode(0));
-		    extList.add(ent);
+                    sideLabels[side].add(lne);
 		    extnodes[ce.getNode(0)] = true;
 		}
 	    }
 	    
+            Collections.sort(sideLabels[ChipElm.SIDE_W], (LabeledNodeElm a, LabeledNodeElm b) -> Integer.signum(a.y - b.y));
+            Collections.sort(sideLabels[ChipElm.SIDE_E], (LabeledNodeElm a, LabeledNodeElm b) -> Integer.signum(a.y - b.y));
+            Collections.sort(sideLabels[ChipElm.SIDE_N], (LabeledNodeElm a, LabeledNodeElm b) -> Integer.signum(a.x - b.x));
+            Collections.sort(sideLabels[ChipElm.SIDE_S], (LabeledNodeElm a, LabeledNodeElm b) -> Integer.signum(a.x - b.x));
+
+            for (int side = 0; side < sideLabels.length; side++) {
+                for (int pos = 0; pos < sideLabels[side].size(); pos++) {
+                    LabeledNodeElm lne = sideLabels[side].get(pos);
+                    ExtListEntry ent = new ExtListEntry(lne.text, lne.getNode(0), pos, side);
+                    extList.add(ent);
+                }
+            }
+
 	    // output all the elements
 	    for (i = 0; i != elmList.size(); i++) {
 		CircuitElm ce = getElm(i);

--- a/src/com/lushprojects/circuitjs1/client/EditCompositeModelDialog.java
+++ b/src/com/lushprojects/circuitjs1/client/EditCompositeModelDialog.java
@@ -75,21 +75,34 @@ public class EditCompositeModelDialog extends Dialog implements MouseDownHandler
             });
             int i;
             int postCount = model.extList.size();
-
-            model.sizeX = 2;
-            model.sizeY = (postCount+1)/2;
+            int sideCounts[] = new int[] { 0, 0, 0, 0 };
             for (i = 0; i != postCount; i++) {
-        	boolean left = i < model.sizeY;
-        	int side = (left) ? ChipElm.SIDE_W : ChipElm.SIDE_E;
         	ExtListEntry pin = model.extList.get(i);
-        	pin.pos = left ? i : i-model.sizeY;
-        	pin.side = side;
+                sideCounts[pin.side] += 1;
+
         	if (nodeSet.contains(pin.node)) {
         	    Window.alert(Locale.LS("Can't have two input/output nodes connected!"));
         	    return false;
         	}
         	nodeSet.add(pin.node);
             }
+
+            int xOffsetLeft = (sideCounts[ChipElm.SIDE_W] > 0) ? 1 : 0;
+            int xOffsetRight = (sideCounts[ChipElm.SIDE_E] > 0) ? 1 : 0;
+            for (i = 0; i != postCount; i++) {
+                ExtListEntry pin = model.extList.get(i);
+                if (pin.side == ChipElm.SIDE_N || pin.side == ChipElm.SIDE_S) {
+                    pin.pos += xOffsetLeft;
+                }
+            }
+
+            int minHeight = (sideCounts[ChipElm.SIDE_N] > 0 && sideCounts[ChipElm.SIDE_S] > 0) ? 2 : 1;
+            int minWidth = 2;
+            int pinsNS = Math.max(sideCounts[ChipElm.SIDE_N], sideCounts[ChipElm.SIDE_S]);
+            int pinsWE = Math.max(sideCounts[ChipElm.SIDE_W], sideCounts[ChipElm.SIDE_E]);
+            model.sizeX = Math.max(minWidth, pinsNS + xOffsetLeft + xOffsetRight);
+            model.sizeY = Math.max(minHeight, pinsWE);
+
             model.modelCircuit = CirSim.theSim.dumpCircuit();
             return true;
         }


### PR DESCRIPTION
This change initializes the pin positions in the "Create subcircuit" dialog from the location of the "Labeled Nodes" in the schematic. The rationale for this change is that this makes it easier to change an existing subcircuit.

Previously the pins were distributed more or less arbitrarily to the left and right side of the symbol. You can drag them to the desired position and save the subcircuit. But when you open a saved subcircuit and then click "Create subcircuit" again, your previous pin arrangement is lost.

With this pull request, the initial pin positions are instead determined from the labeled nodes in the schematic. Labels that "point upward" are placed on the north edge of the symbol, nodes that "point right" on the east edge, etc. Additionally, the pins are sorted on the symbol in the same order as they appear in the schematic, from top to bottom (for horizontal pins) or from left to right (for vertical pins). This means that you don't have to repeat the positioning of pins over and over again when iteratively changing a subcircuit, but you can do it once in the schematic and then the symbol is automatically created accordingly.

The symbol is automatically sized that all pins fit inside. Care is taken to ensure that the pin labels of vertical and horizontal pins do not overlap.

Here are some examples:

https://www.falstad.com/circuit/circuitjs.html?ctz=CQAgjCAMB0l3BWcMBMcUHYMGZIA4UA2ATmIxAUgpABZsKBTAWjDACg1y08Q8qxCVPrRAB1SB0jlsCFLyo0B8kQFEJAJxDdlMucP7w2QA

![image](https://user-images.githubusercontent.com/3628933/207389591-37d7c60c-28f0-47be-a3f3-64c6504db85e.png) ![image](https://user-images.githubusercontent.com/3628933/207389628-e4f3c5ae-764f-4256-9fae-5133f658ae7c.png)


https://www.falstad.com/circuit/circuitjs.html?ctz=CQAgjCAMB0l3BWcMBMcUHYMGZIA4UA2ATmIxAUgpABZsKBTAWjDACg1y09wNCRuAmlRogAypA6RyrFCDxVCohbRAB1SQCcB+eVVzKqVMPClddLfoKZLVAOS06elp3qjI4bbbLeCVx020-KkEwPncTTyA

![image](https://user-images.githubusercontent.com/3628933/207388098-39104d3c-bbe6-45be-80d6-70c2f28b1907.png) ![image](https://user-images.githubusercontent.com/3628933/207388149-5cbbdf2e-9713-4069-8ae4-e22f23809732.png)

https://www.falstad.com/circuit/circuitjs.html?ctz=CQAgjCAMB0l3BWcMBMcUHYMGZIA4UA2ATmIxAUgpABZsKBTAWjDACg1y09wwVxCVVvxogA6u04hco7Pxkgmc2iABykyF3zhi-MIJ0jxKDppDcQeIQasqxkU1wSFp-FM8XLRqh1OwJ+Wxp9SypRAFFfMwsUFFELBVEAZSjyfzc46QDpSFFkkz9c80yFRJAk9gAncw9lC1sheDZq9OLZbIbkOGac+MyYzMbu6oswXXNtYSguhxaiutr+IYcgA

![image](https://user-images.githubusercontent.com/3628933/207388295-aeb86aa2-e5e2-486b-9030-b3f432053b98.png) ![image](https://user-images.githubusercontent.com/3628933/207388333-12002c43-c9f8-4593-9d10-da9da7b36639.png)

https://www.falstad.com/circuit/circuitjs.html?ctz=CQAgjCAMB0l3BWcMBMcUHYMGZIA4UA2ATmIxAUgpABZsKBTAWjDACg1zcbwaexiKcCjy0QAdXacQ2bIRlDZ8ptiE8AclMjkaYeXqo08VA2ICiW8mlEChp62PEoO2kChQ9j4DPK89xkC5WGIpCKAjKRmLqgdJ0obRRKmog6s5xUV4IYHYi5rGuuvKYasTFHubprg7hxfgycmIAygVcCGEVJQ3yPE1VVniiHlTc3c3sAE5uIQpuFV4m8GxT8bNKs4twyzLtczxF00KbgVMiQzRUNRFQyFun9bYykPx8N2BLK3rghIaZVMdsIA

![image](https://user-images.githubusercontent.com/3628933/207388483-f0b820dc-35c7-4a88-bee1-506b3881dc7d.png) ![image](https://user-images.githubusercontent.com/3628933/207388522-dc9e7bf6-3653-4e31-a763-798f0a664b15.png)
