### PR TITLE
Add a color picker instead of a textbox for color selection

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/EditDialog.java
+++ b/src/com/lushprojects/circuitjs1/client/EditDialog.java
@@ -162,6 +162,10 @@ class EditDialog extends Dialog {
 			    if (ei.text == null) {
 				ei.textf.setText(unitString(ei));
 			    }
+				if (ei.isColor){
+				ei.textf.getElement().setAttribute("type", "color");
+				ei.textf.getElement().setAttribute("style", "width:178px;padding:0");
+				}
 			}
 			if (vp.getWidgetCount() > 15) {
 			    // start a new column

--- a/src/com/lushprojects/circuitjs1/client/EditInfo.java
+++ b/src/com/lushprojects/circuitjs1/client/EditInfo.java
@@ -77,6 +77,7 @@ class EditInfo {
 	boolean dimensionless;
 	boolean noSliders;
 	double minVal, maxVal;
+	boolean isColor = false;
 	
 	// for slider dialog
 	TextBox minBox, maxBox, labelBox;

--- a/src/com/lushprojects/circuitjs1/client/EditOptions.java
+++ b/src/com/lushprojects/circuitjs1/client/EditOptions.java
@@ -55,16 +55,36 @@ class EditOptions implements Editable {
 	            return ei;
 		}
 		
-		if (n == 3)
-		    return new EditInfo("Positive Color", CircuitElm.positiveColor.getHexValue());
-		if (n == 4)
-		    return new EditInfo("Negative Color", CircuitElm.negativeColor.getHexValue());
-		if (n == 5)
-		    return new EditInfo("Neutral Color", CircuitElm.neutralColor.getHexValue());
-		if (n == 6)
-		    return new EditInfo("Selection Color", CircuitElm.selectColor.getHexValue());
-		if (n == 7)
-		    return new EditInfo("Current Color", CircuitElm.currentColor.getHexValue());
+		if (n == 3){
+			EditInfo ei = new EditInfo("Positive Color", CircuitElm.positiveColor.getHexValue());
+			ei.isColor = true;
+			return ei;
+		}
+		    
+		if (n == 4){
+			EditInfo ei = new EditInfo("Negative Color", CircuitElm.negativeColor.getHexValue());
+			ei.isColor = true;
+			return ei;
+		}
+		    
+		if (n == 5){
+			EditInfo ei = new EditInfo("Neutral Color", CircuitElm.neutralColor.getHexValue());
+			ei.isColor = true;
+			return ei;
+		}
+		    
+		if (n == 6){
+			EditInfo ei = new EditInfo("Selection Color", CircuitElm.selectColor.getHexValue());
+			ei.isColor = true;
+			return ei;
+		}
+		    
+		if (n == 7){
+			EditInfo ei = new EditInfo("Current Color", CircuitElm.currentColor.getHexValue());
+			ei.isColor = true;
+			return ei;
+		}
+		    
 		if (n == 8)
 		    return new EditInfo("# of Decimal Digits (short format)", CircuitElm.shortDecimalDigits);
 		if (n == 9)


### PR DESCRIPTION
Hello. I would like to suggest replacing the textbox with the browser color picker in `Other Options...`.
To do this, simply change the type attribute in the textf element:
```
ei.textf.getElement().setAttribute("type", "color");
```
This simply replaces the `<input type="text">` element with a `<input type="color">` element.
The `<input type="color">` element accepts values ​​in `#rrggbb` hexadecimal format. For GWT there is no difference between the `type="color"` and the `type="text"`, so the getText() function in EditOptions.java:
```
String val = ei.textf.getText();
```
will return the value of the `value` attribute.

Here’s how it looks in Chromium and Firefox:
<img src="https://github.com/user-attachments/assets/995b64b4-3cf9-41e6-9fd3-4862def433bd" width=40% height=40%><img src="https://github.com/user-attachments/assets/4e55dc8b-d8bf-4d8c-ad53-32a24000670f" width=40% height=40%>

Chromium has its own implementation of color selection:
<img src="https://github.com/user-attachments/assets/6656de7a-c77b-4091-befe-0fa1744d27a6" width=30% height=30%>

Firefox seems to be using system libraries. Firefox on Windows:
<img src="https://github.com/user-attachments/assets/152ec107-c96c-42cb-b5eb-c2f31720269e" width=40% height=40%>

Firefox on Linux:
<img src="https://github.com/user-attachments/assets/c28061e7-bef0-4e5e-b3f4-567d8430b813" width=40% height=40%><img src="https://github.com/user-attachments/assets/b937114c-e903-43c5-85aa-02cb8579d757" width=40% height=40%>

I haven’t tested the implementation in Safari but according to the [specification](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/color) this element is supported by all browsers.

I hope that I managed to explain everything clearly with my not very good English.