### PR TITLE
Fixes the D flip flop behavior when both SET and RESET are active at the same time

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/DFlipFlopElm.java
+++ b/src/com/lushprojects/circuitjs1/client/DFlipFlopElm.java
@@ -85,7 +85,7 @@ package com.lushprojects.circuitjs1.client;
 	    if (hasSet() && pins[5].value != invertSetReset())
 		isSet = true;
 	    if (hasReset() && pins[4].value != invertSetReset())
-		isReset = false;
+		isReset = true;
 
 	    if (isSet || isReset) {
 	    	writeOutput(1, false);

--- a/src/com/lushprojects/circuitjs1/client/DFlipFlopElm.java
+++ b/src/com/lushprojects/circuitjs1/client/DFlipFlopElm.java
@@ -79,13 +79,28 @@ package com.lushprojects.circuitjs1.client;
                 return;
             }
 	    
-	    if (pins[3].value && !lastClock)
-		writeOutput(1, pins[0].value);
-	    if(hasSet() && pins[5].value != invertSetReset())
-		writeOutput(1, true);
-	    if(hasReset() && pins[4].value != invertSetReset())
-		writeOutput(1, false);
-	    writeOutput(2, !pins[1].value);
+	    boolean isSet = false;
+            boolean isReset = false;
+            
+	    if (hasSet() && pins[5].value != invertSetReset())
+		isSet = true;
+	    if (hasReset() && pins[4].value != invertSetReset())
+		isReset = false;
+
+	    if (isSet || isReset) {
+	    	writeOutput(1, false);
+		writeOutput(2, false);
+                if (isSet)
+                    writeOutput(1, true);
+                if (isReset)
+                    writeOutput(2, true);
+            } else {
+                if (pins[3].value && !lastClock)
+		    writeOutput(1, pins[0].value);
+
+                writeOutput(2, !pins[1].value);
+            }
+
 	    lastClock = pins[3].value;
 	}
 	int getDumpType() { return 155; }


### PR DESCRIPTION
According to both the CD4013 and the 74xx74 dual D type FF datasheets (linked below), when both SET and RESET are active at the same time, the chip reacts by having BOTH Q and notQ outputs high at the same time.
The previous implementation didn't seem to model this, so I figured I'd try to do it.

It's completely untested, so take it for what it's worth :-)

CD4013 datasheet: https://www.ti.com/lit/ds/symlink/cd4013b.pdf (see page 10. This has active-high SET and RESET pins)
74LS74 datasheet: https://www.ti.com/lit/ds/symlink/sn74s74.pdf (the truth table is on the first page. This has active-low SET and RESET inputs)