### PR TITLE
Fix carry value when loading on the second-to-last clock cycle before overflow

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/Counter2Elm.java
+++ b/src/com/lushprojects/circuitjs1/client/Counter2Elm.java
@@ -132,6 +132,18 @@ class Counter2Elm extends ChipElm {
 		    int i;
 		    for (i = 0; i != bits; i++)
 			writeOutput(i, pins[i+bits].value);
+
+		    int value = 0;
+
+		    // get current value
+		    int lastBit = bits-1;
+		    for (i = 0; i != bits; i++)
+			if (pins[lastBit-i].value)
+			    value |= 1<<i;
+
+		    int realmod = (modulus == 0) ? (1<<bits) : modulus;
+
+		    carry = (value == realmod-1);
 		}
 	    }
 	    if (!pins[clr].value) {


### PR DESCRIPTION
I just noticed a little thing which I believe is a bug.

Suppose you have a 4 bit counter with load (something like an 74xx161 ( https://www.ti.com/lit/ds/symlink/sn74ls161a.pd )
Let's say that the counter is now at value 14, the second-to-last value in the sequence before it rolls over to 0. If I bring the LOAD input low and keep it there until the next clock pulse appears, then the counter jumps to whatever value is programmed by the input pins. So if the counter is configured to, say, load the value 3, it will do so. So far so good.

The problem is that the carry pin does not behave as expected. It appears that its value is computed as if no LOAD was executed, which is incorrect. If that chip is used as part of a chain of counters, relying on the carry output to synchronize them all, this can wreck havoc on the counter behavior.

I tried to fix the issue in this PR. Basically I tried to detect the carry value after the value is loaded. This should also work in case someone tries to load the max value (i.e. if someone loads 15 in a 4-bit counter, for example).
Since the counter is configurable with an arbitrary modulo value, I couldn't just check whether all bits loaded are 1, I had to convert the loaded value into decimal and then compare it to the modulo. That's why I copy-pasted a block of code from a few lines above.

Here is a minimal test circuit for the described scenario. Notice the behavior of the carry output when the counter jumps from 14 to 3.

https://www.falstad.com/circuit/circuitjs.html?ctz=CQAgjCAMB0l3BWcMBMcUHYMGZIA4UA2ATmIxAUgoqoQFMBaMMAKABYUIE22QU3ahKvypVetKJMgsAShR4gBtMCkVwpa6qKjQEs+bzbZVCFYuMaBWqbv2ErR1YQyrHlidph6AMgb4vFYkJ-VVUqADMAQwAbAGc6LRYAWRB7YStCPDw+K2FbX25eXEMgkGK+SSi4hKRpAoVsbGC2Usbg1Qgq+MT6oszA4KbsjpAumqgWAHcQLKpy2bVRKdSHdQWlCblCnOVQqwgO9RRdPhPRW2m0kJAcdoDpadvrp5QsicurNpumsp+H78GPyexiWjx+IJuCFUEP+LzeGChfDesMR5Su5X+eDY2XmeDmkHELDApkh0IJM2xZXJc2oeiAA
