### PR TITLE
Added container files, added env-vars in dev.sh

### DIFF
--- a/circuitjs1.Containerfile
+++ b/circuitjs1.Containerfile
@@ -1,0 +1,16 @@
+FROM docker.io/library/gradle:jdk8-ubi
+
+
+RUN microdnf install -y python3 && microdnf clean all
+COPY . /src
+
+WORKDIR /src
+
+RUN cd /src &&\
+    gradle compileGwt --console verbose --info &&\
+    gradle makeSite --console verbose --info
+
+
+EXPOSE 8000
+
+CMD cd /src/site && python3 -m http.server

--- a/dev-start.Containerfile
+++ b/dev-start.Containerfile
@@ -1,0 +1,20 @@
+FROM docker.io/library/ubuntu:24.04
+
+
+RUN apt update && apt upgrade -y &&\
+    apt install -y openjdk-8-jdk-headless ant wget unzip python3 python-is-python3 &&\
+    apt clean
+
+COPY . /src
+
+WORKDIR /src
+
+RUN cd /src && ./dev.sh setup
+
+ENV WEB_BINDADDRESS=0.0.0.0
+ENV CODESERVER_BINDADDRESS=0.0.0.0
+
+EXPOSE 8000
+EXPOSE 9876
+
+CMD ./dev.sh start

--- a/dev.sh
+++ b/dev.sh
@@ -12,6 +12,10 @@ SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 SDK_DIR="$SCRIPT_DIR/.."
 GWT_DIR="$SDK_DIR/gwt-$GWT_VERSION"
 
+WEB_PORT=${WEB_PORT:-8000}
+WEB_BINDADDRESS=${WEB_BINDADDRESS:-127.0.0.1}
+CODESERVER_BINDADDRESS=${CODESERVER_BINDADDRESS:-127.0.0.1}
+
 compile() {
     ant build
 }
@@ -61,6 +65,7 @@ codeserver() {
     java -classpath "src:$GWT_DIR/gwt-codeserver.jar:$GWT_DIR/gwt-dev.jar:$GWT_DIR/gwt-user.jar" \
         com.google.gwt.dev.codeserver.CodeServer \
         -launcherDir war \
+	-bindAddress ${CODESERVER_BINDADDRESS} \
         com.lushprojects.circuitjs1.circuitjs1
 }
 
@@ -69,12 +74,12 @@ webserver() {
 
     (
         cd $webroot
-        python -m http.server
+        python3 -m http.server --bind ${WEB_BINDADDRESS} ${WEB_PORT}
     )
 }
 
 start() {
-    echo "Starting web server http://127.0.0.1:8000"
+    echo "Starting web server http://${WEB_BINDADDRESS}:${WEB_PORT}"
     trap "pkill -f \"python -m http.server\"" EXIT
     webserver >"webserver.log" 2>&1 &
     sleep 0.5


### PR DESCRIPTION
# Changes: 
 - Added containerfile: circuitjs1.Containerfile
 - Added containerfile: dev-start.Containerfile
 - Small changes: dev.sh
  
# circuitjs1.Containerfile
Example: build with podman:
 ```podman build -f circuitjs1.Containerfile -t  circuitjs1:latest```

Example run with podman:
```podman run --name=circuitjs1 --rm -d -p 8000:8000 circuitjs1:latest```    

#  dev-start.Containerfile
Example: build with podman:
```podman build -f dev-start.Containerfile -t  circuitjs1-dev:latest```
Example run with podman:
```podman run -it -p 127.0.0.1:8000:8000/tcp -p 127.0.0.1:9876:9876/tcp circuitjs1-dev:latest```   
Or if you develop on your host, you might want the local-repo and container /src/ directory to be the same:
e.g.:
```podman run --rm -it -v $(pwd):/src:Z  -p 127.0.0.1:8000:8000/tcp -p 127.0.0.1:9876:9876/tcp  circuitjs1-dev:latest```

# dev.sh
  Added support for ENVIRONMENT variable override of webserver port and bindaddress (needed for container networks).
  Specified python3 as binary for the webserver
    