### PR TITLE
Modify the toolbar

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/CirSim.java
+++ b/src/com/lushprojects/circuitjs1/client/CirSim.java
@@ -130,6 +130,7 @@ MouseOutHandler, MouseWheelHandler {
     CheckboxMenuItem noEditCheckItem;
     CheckboxMenuItem mouseWheelEditCheckItem;
     CheckboxMenuItem toolbarCheckItem;
+    CheckboxMenuItem mouseModeCheckItem;
     private Label powerLabel;
     private Label titleLabel;
     private Scrollbar speedBar;
@@ -611,6 +612,12 @@ MouseOutHandler, MouseWheelHandler {
 		}
 	}));
 	toolbarCheckItem.setState(!hideMenu && !noEditing && !hideSidebar && startCircuit == null && startCircuitText == null && startCircuitLink == null);
+	m.addItem(mouseModeCheckItem = new CheckboxMenuItem(Locale.LS("Show Mode"),
+		new Command() { public void execute(){
+			setOptionInStorage("showMouseMode", mouseModeCheckItem.getState());
+		}
+	}));
+	mouseModeCheckItem.setState(getOptionFromStorage("showMouseMode", true));
 	m.addItem(crossHairCheckItem = new CheckboxMenuItem(Locale.LS("Show Cursor Cross Hairs"),
 		new Command() { public void execute(){
 		    setOptionInStorage("crossHair", crossHairCheckItem.getState());
@@ -1715,8 +1722,10 @@ MouseOutHandler, MouseWheelHandler {
         }
 
         // Add info about mouse mode in graphics
-        if (printableCheckItem.getState()) g.setColor(Color.black);
-        g.drawString(Locale.LS("Mode: ") + classToLabelMap.get(mouseModeStr), 10, 29);
+        if (mouseModeCheckItem.getState()){
+            if (printableCheckItem.getState()) g.setColor(Color.black);
+            g.drawString(Locale.LS("Mode: ") + classToLabelMap.get(mouseModeStr), 10, 29);
+        }
         
         // This should always be the last 
         // thing called by updateCircuit();

--- a/src/com/lushprojects/circuitjs1/client/CirSim.java
+++ b/src/com/lushprojects/circuitjs1/client/CirSim.java
@@ -1697,7 +1697,7 @@ MouseOutHandler, MouseWheelHandler {
         perfmon.stopContext(); // updateCircuit
         
         if (developerMode) {
-            int height = 15;
+            int height = 45;
             int increment = 15;
             g.drawString("Framerate: " + CircuitElm.showFormat.format(framerate), 10, height);
             g.drawString("Steprate: " + CircuitElm.showFormat.format(steprate), 10, height += increment);
@@ -1713,6 +1713,10 @@ MouseOutHandler, MouseWheelHandler {
                 g.drawString(splits[x], 10, height + (increment * x));
             }
         }
+
+        // Add info about mouse mode in graphics
+        if (printableCheckItem.getState()) g.setColor(Color.black);
+        g.drawString(Locale.LS("Mode: ") + classToLabelMap.get(mouseModeStr), 10, 29);
         
         // This should always be the last 
         // thing called by updateCircuit();
@@ -5673,7 +5677,7 @@ MouseOutHandler, MouseWheelHandler {
     }
     
     void updateToolbar() {
-	toolbar.setModeLabel(classToLabelMap.get(mouseModeStr));
+	//toolbar.setModeLabel(classToLabelMap.get(mouseModeStr));
 	toolbar.highlightButton(mouseModeStr);
     }
 

--- a/src/com/lushprojects/circuitjs1/client/Toolbar.java
+++ b/src/com/lushprojects/circuitjs1/client/Toolbar.java
@@ -89,6 +89,7 @@ public class Toolbar extends HorizontalPanel {
 			      orIcon, "OrGateElm", norIcon, "NorGateElm", xorIcon, "XorGateElm" };
 	add(createButtonSet(gateInfo));
 
+	/*
         // Spacer to push the mode label to the right
         HorizontalPanel spacer = new HorizontalPanel();
         //spacer.style.setFlexGrow(1); // Fill remaining space
@@ -98,9 +99,10 @@ public class Toolbar extends HorizontalPanel {
         modeLabel = new Label("");
         styleModeLabel(modeLabel);
         add(modeLabel);
+	*/
     }
 
-    public void setModeLabel(String text) { modeLabel.setText(Locale.LS("Mode: ") + text); }
+    //public void setModeLabel(String text) { modeLabel.setText(Locale.LS("Mode: ") + text); }
 
     private Label createIconButton(String icon, String cls) {
 	CirSim sim = CirSim.theSim;

--- a/src/com/lushprojects/circuitjs1/client/Toolbar.java
+++ b/src/com/lushprojects/circuitjs1/client/Toolbar.java
@@ -44,6 +44,7 @@ public class Toolbar extends HorizontalPanel {
 	} else {
 		add(createIconButton("floppy", "Save As...", new MyCommand("file", "exportaslocalfile")));
 	}
+	add(new HTML("<sup style=\"margin-left:-12px;\"><strong>+</strong></sup>")); // add symbol to "Save As" icon for the visual difference
 	add(new HTML(SEPARATOR));
 	add(createIconButton("ccw", "Undo", new MyCommand("edit", "undo")));
 	add(createIconButton("cw",  "Redo", new MyCommand("edit", "redo")));

--- a/src/com/lushprojects/circuitjs1/client/Toolbar.java
+++ b/src/com/lushprojects/circuitjs1/client/Toolbar.java
@@ -36,6 +36,15 @@ public class Toolbar extends HorizontalPanel {
         style.setDisplay(Style.Display.FLEX);
 	setVerticalAlignment(ALIGN_MIDDLE);
 
+	add(createIconButton("doc-new", "New Blank Circuit", new MyCommand("file", "newblankcircuit")));
+	add(createIconButton("folder",  "Open File...", new MyCommand("file", "importfromlocalfile")));
+	if (CirSim.isElectron()) {
+		add(createIconButton("floppy", "Save", new MyCommand("file", "save")));
+		add(createIconButton("floppy", "Save As...", new MyCommand("file", "saveas")));
+	} else {
+		add(createIconButton("floppy", "Save As...", new MyCommand("file", "exportaslocalfile")));
+	}
+	add(new HTML(SEPARATOR));
 	add(createIconButton("ccw", "Undo", new MyCommand("edit", "undo")));
 	add(createIconButton("cw",  "Redo", new MyCommand("edit", "redo")));
 	add(new HTML(SEPARATOR));

--- a/src/com/lushprojects/circuitjs1/client/Toolbar.java
+++ b/src/com/lushprojects/circuitjs1/client/Toolbar.java
@@ -39,7 +39,8 @@ public class Toolbar extends HorizontalPanel {
 	add(createIconButton("doc-new", "New Blank Circuit", new MyCommand("file", "newblankcircuit")));
 	add(createIconButton("folder",  "Open File...", new MyCommand("file", "importfromlocalfile")));
 	if (CirSim.isElectron()) {
-		add(createIconButton("floppy", "Save", new MyCommand("file", "save")));
+		// Additional conditions are required: "Save" should not be available always.
+		//add(createIconButton("floppy", "Save", new MyCommand("file", "save")));
 		add(createIconButton("floppy", "Save As...", new MyCommand("file", "saveas")));
 	} else {
 		add(createIconButton("floppy", "Save As...", new MyCommand("file", "exportaslocalfile")));

--- a/src/com/lushprojects/circuitjs1/client/Toolbar.java
+++ b/src/com/lushprojects/circuitjs1/client/Toolbar.java
@@ -21,6 +21,7 @@ public class Toolbar extends HorizontalPanel {
     private Label modeLabel;
     private HashMap<String, Label> highlightableButtons = new HashMap<>();
     private Label activeButton;  // Currently active button
+    private String SEPARATOR = "<div style=\"height:30px;width:0;border-left:2px solid grey;\"></div>";
 
     Label resistorButton;
 
@@ -37,16 +38,18 @@ public class Toolbar extends HorizontalPanel {
 
 	add(createIconButton("ccw", "Undo", new MyCommand("edit", "undo")));
 	add(createIconButton("cw",  "Redo", new MyCommand("edit", "redo")));
+	add(new HTML(SEPARATOR));
 	add(createIconButton("scissors", "Cut", new MyCommand("edit", "cut")));
 	add(createIconButton("copy", "Copy", new MyCommand("edit", "copy")));
 	add(createIconButton("paste", "Paste", new MyCommand("edit", "paste")));
 	add(createIconButton("clone", "Duplicate", new MyCommand("edit", "duplicate")));
+	add(new HTML(SEPARATOR));
 	add(createIconButton("search", "Find Component...", new MyCommand("edit", "search")));
-
+	add(new HTML(SEPARATOR));
 	add(createIconButton("zoom-11", "Zoom 100%", new MyCommand("zoom", "zoom100")));
 	add(createIconButton("zoom-in", "Zoom In", new MyCommand("zoom", "zoomin")));
 	add(createIconButton("zoom-out", "Zoom Out", new MyCommand("zoom", "zoomout")));
-
+	add(new HTML(SEPARATOR));
 	add(createIconButton(wireIcon, "WireElm"));
 	add(resistorButton = createIconButton(resistorIcon, "ResistorElm"));
 	add(createIconButton(groundIcon, "GroundElm"));

--- a/src/com/lushprojects/circuitjs1/client/Toolbar.java
+++ b/src/com/lushprojects/circuitjs1/client/Toolbar.java
@@ -56,6 +56,7 @@ public class Toolbar extends HorizontalPanel {
 	add(new HTML(SEPARATOR));
 	add(createIconButton("search", "Find Component...", new MyCommand("edit", "search")));
 	add(new HTML(SEPARATOR));
+	add(createIconButton("target", "Centre Circuit", new MyCommand("edit", "centrecircuit")));
 	add(createIconButton("zoom-11", "Zoom 100%", new MyCommand("zoom", "zoom100")));
 	add(createIconButton("zoom-in", "Zoom In", new MyCommand("zoom", "zoomin")));
 	add(createIconButton("zoom-out", "Zoom Out", new MyCommand("zoom", "zoomout")));


### PR DESCRIPTION
I tried to make this as comfortable as possible but perhaps you may not like some of this changes. At first, I just wanted to add separators but I did not stop at this. In general:
- Added separators to the toolbar
- Added file options to the toolbar (new, open file, save, save as)
- Added symbol "+" to "Save As" icon for the visual differences between "save" and "save as"
- Added "Centre Circuit" option to the toolbar
- Moved info about mouse mode from the toolbar to the work area (graphics)
- Added chechbox in options for show/hide info about mouse mode

Upd: I hid the "Save" option on toolbar for Electron because need additional conditions for it. It should not be available always.

Screenshot:
![Снимок экрана_2025-05-03_21-00-35](https://github.com/user-attachments/assets/a02019df-99a7-4425-afa5-ca39fa2c48f1)
