### PR TITLE
Add color picker and reset colors button

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/EditDialog.java
+++ b/src/com/lushprojects/circuitjs1/client/EditDialog.java
@@ -71,7 +71,7 @@ class EditDialog extends Dialog {
 //		setLayout(new EditDialogLayout());
 		mainPanel=new VerticalPanel();
 		setWidget(mainPanel);
-		einfos = new EditInfo[10];
+		einfos = new EditInfo[20];
 //		noCommaFormat = DecimalFormat.getInstance();
 //		noCommaFormat.setMaximumFractionDigits(10);
 //		noCommaFormat.setGroupingUsed(false);
@@ -165,7 +165,10 @@ class EditDialog extends Dialog {
 			    vp.add(ei.textf = new TextBox());
 			    if (ei.text != null) {
 				ei.textf.setText(ei.text);
-				ei.textf.setVisibleLength(50);
+				if (ei.isColor)
+				    ei.textf.getElement().setAttribute("type", "color");
+				else
+				    ei.textf.setVisibleLength(50);
 			    }
 			    if (ei.text == null) {
 				ei.textf.setText(unitString(ei));

--- a/src/com/lushprojects/circuitjs1/client/EditInfo.java
+++ b/src/com/lushprojects/circuitjs1/client/EditInfo.java
@@ -54,6 +54,7 @@ class EditInfo {
 	
 	EditInfo setDimensionless() { dimensionless = true; return this; }
 	EditInfo disallowSliders() { noSliders = true; return this; }
+	EditInfo setIsColor() { isColor = true; return this; }
 	int changeFlag(int flags, int bit) {
 	    if (checkbox.getState())
 		return flags | bit;
@@ -77,6 +78,7 @@ class EditInfo {
 	boolean newDialog;
 	boolean dimensionless;
 	boolean noSliders;
+	boolean isColor;
 	double minVal, maxVal;
 	
 	// for slider dialog

--- a/src/com/lushprojects/circuitjs1/client/EditOptions.java
+++ b/src/com/lushprojects/circuitjs1/client/EditOptions.java
@@ -21,6 +21,7 @@ package com.lushprojects.circuitjs1.client;
 
 import com.google.gwt.storage.client.Storage;
 import com.google.gwt.user.client.Window;
+import com.google.gwt.user.client.ui.Button;
 import com.lushprojects.circuitjs1.client.util.Locale;
 
 class EditOptions implements Editable {
@@ -57,34 +58,39 @@ class EditOptions implements Editable {
 		}
 		
 		if (n == 3)
-		    return new EditInfo("Positive Color", CircuitElm.positiveColor.getHexValue());
+		    return new EditInfo("Positive Color", CircuitElm.positiveColor.getHexValue()).setIsColor();
 		if (n == 4)
-		    return new EditInfo("Negative Color", CircuitElm.negativeColor.getHexValue());
+		    return new EditInfo("Negative Color", CircuitElm.negativeColor.getHexValue()).setIsColor();
 		if (n == 5)
-		    return new EditInfo("Neutral Color", CircuitElm.neutralColor.getHexValue());
+		    return new EditInfo("Neutral Color", CircuitElm.neutralColor.getHexValue()).setIsColor();
 		if (n == 6)
-		    return new EditInfo("Selection Color", CircuitElm.selectColor.getHexValue());
+		    return new EditInfo("Selection Color", CircuitElm.selectColor.getHexValue()).setIsColor();
 		if (n == 7)
-		    return new EditInfo("Current Color", CircuitElm.currentColor.getHexValue());
-		if (n == 8)
-		    return new EditInfo("# of Decimal Digits (short format)", CircuitElm.shortDecimalDigits);
+		    return new EditInfo("Current Color", CircuitElm.currentColor.getHexValue()).setIsColor();
+		if (n == 8) {
+		    EditInfo ei = new EditInfo("", 0, -1, -1);
+		    ei.button = new Button(Locale.LS("Reset Colors to Default"));
+		    return ei;
+		}
 		if (n == 9)
+		    return new EditInfo("# of Decimal Digits (short format)", CircuitElm.shortDecimalDigits);
+		if (n == 10)
 		    return new EditInfo("# of Decimal Digits (long format)", CircuitElm.decimalDigits);
-		if (n == 10) {
+		if (n == 11) {
 		    EditInfo ei = new EditInfo("", 0, -1, -1);
 		    ei.checkbox = new Checkbox("Developer Mode", sim.developerMode);
 		    return ei;
 		}
-		if (n == 11)
-		    return new EditInfo("Minimum Target Frame Rate", sim.minFrameRate);
 		if (n == 12)
+		    return new EditInfo("Minimum Target Frame Rate", sim.minFrameRate);
+		if (n == 13)
 		    return new EditInfo("Mouse Wheel Sensitivity", sim.wheelSensitivity);
-		if (n == 13) {
+		if (n == 14) {
 		    EditInfo ei = new EditInfo("", 0, -1, -1);
 		    ei.checkbox = new Checkbox("Auto-Adjust Timestep", sim.adjustTimeStep);
 		    return ei;
 		}
-		if (n == 14 && sim.adjustTimeStep)
+		if (n == 15 && sim.adjustTimeStep)
 		    return new EditInfo("Minimum time step size (s)", sim.minTimeStep, 0, 0);
 
 		return null;
@@ -149,25 +155,43 @@ class EditOptions implements Editable {
 		    CircuitElm.selectColor = setColor("selectColor", ei, Color.cyan);
 		if (n == 7)
 		    CircuitElm.currentColor = setColor("currentColor", ei, Color.yellow);
-		if (n == 8)
-		    CircuitElm.setDecimalDigits((int)ei.value, true, true);
+		if (n == 8) {
+		    // Reset all colors to defaults
+		    Storage stor = Storage.getLocalStorageIfSupported();
+		    if (stor != null) {
+			stor.removeItem("positiveColor");
+			stor.removeItem("negativeColor");
+			stor.removeItem("neutralColor");
+			stor.removeItem("selectColor");
+			stor.removeItem("currentColor");
+		    }
+		    CircuitElm.positiveColor = Color.green;
+		    CircuitElm.negativeColor = Color.red;
+		    CircuitElm.neutralColor = Color.gray;
+		    CircuitElm.selectColor = Color.cyan;
+		    CircuitElm.currentColor = Color.yellow;
+		    CircuitElm.setColorScale();
+		    ei.newDialog = true;
+		}
 		if (n == 9)
-		    CircuitElm.setDecimalDigits((int)ei.value, false, true);
+		    CircuitElm.setDecimalDigits((int)ei.value, true, true);
 		if (n == 10)
+		    CircuitElm.setDecimalDigits((int)ei.value, false, true);
+		if (n == 11)
 	            sim.developerMode = ei.checkbox.getState();
-		if (n == 11 && ei.value > 0)
+		if (n == 12 && ei.value > 0)
 		    sim.minFrameRate = ei.value;
-		if (n == 12 && ei.value > 0) {
+		if (n == 13 && ei.value > 0) {
 		    sim.wheelSensitivity = ei.value;
 		    Storage stor = Storage.getLocalStorageIfSupported();
 		    if (stor != null)
 			stor.setItem("wheelSensitivity", Double.toString(sim.wheelSensitivity));
 		}
-		if (n == 13) {
+		if (n == 14) {
 		    sim.adjustTimeStep = ei.checkbox.getState();
 		    ei.newDialog = true;
 		}
-		if (n == 14 && ei.value > 0)
+		if (n == 15 && ei.value > 0)
 		    sim.minTimeStep = ei.value;
 	}
 	


### PR DESCRIPTION
## Summary

- Replaces text input with native HTML5 color picker for the 5 color settings in Other Options (Positive, Negative, Neutral, Selection, Current Color)
- Adds a "Reset Colors to Default" button that clears localStorage overrides and restores factory defaults
- Increases EditInfo array size from 10 to 20 to prevent potential overflow with all current options

This builds on the approach from PR #121 by @SEVA77, incorporating the reset button that @pfalstad [requested](https://github.com/pfalstad/circuitjs1/pull/121#issuecomment-2480135116).

## Changes

| File | Change |
|------|--------|
| EditInfo.java | Add isColor flag and setIsColor() chainable method |
| EditDialog.java | Set type="color" attribute on TextBox when isColor is true; increase einfos array to 20 |
| EditOptions.java | Mark color fields with .setIsColor(), add reset button at index 8, shift subsequent indices |

## How it looks

The native browser color picker replaces the hex text input. Chromium, Firefox, and Safari all support input type="color" and each renders their own native picker (see PR #121 for screenshots from @SEVA77).

The "Reset Colors to Default" button:
- Removes all 5 color keys from localStorage
- Resets to: green, red, gray, cyan, yellow
- Rebuilds the dialog to show updated values
- Calls setColorScale() to regenerate the voltage gradient

## Test plan

- [ ] Open Other Options dialog - verify color pickers render instead of text fields
- [ ] Change a color - verify it persists across page reload
- [ ] Click "Reset Colors to Default" - verify all 5 colors revert and dialog refreshes
- [ ] Verify other options below colors (decimal digits, developer mode, etc.) still work correctly

Verified: GWT compilation succeeds with gradle compileGwt.

Generated with [Claude Code](https://claude.com/claude-code)
