### PR TITLE
Toolbar enhancements: file ops, separators, centre circuit, show mode toggle

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/CirSim.java
+++ b/src/com/lushprojects/circuitjs1/client/CirSim.java
@@ -130,6 +130,7 @@ MouseOutHandler, MouseWheelHandler {
     CheckboxMenuItem noEditCheckItem;
     CheckboxMenuItem mouseWheelEditCheckItem;
     CheckboxMenuItem toolbarCheckItem;
+    CheckboxMenuItem mouseModeCheckItem;
     private Label powerLabel;
     private Label titleLabel;
     private Scrollbar speedBar;
@@ -611,6 +612,12 @@ MouseOutHandler, MouseWheelHandler {
 		}
 	}));
 	toolbarCheckItem.setState(!hideMenu && !noEditing && !hideSidebar && startCircuit == null && startCircuitText == null && startCircuitLink == null);
+	m.addItem(mouseModeCheckItem = new CheckboxMenuItem(Locale.LS("Show Mode"),
+		new Command() { public void execute(){
+			setOptionInStorage("showMouseMode", mouseModeCheckItem.getState());
+		}
+	}));
+	mouseModeCheckItem.setState(getOptionFromStorage("showMouseMode", true));
 	m.addItem(crossHairCheckItem = new CheckboxMenuItem(Locale.LS("Show Cursor Cross Hairs"),
 		new Command() { public void execute(){
 		    setOptionInStorage("crossHair", crossHairCheckItem.getState());
@@ -1697,7 +1704,7 @@ MouseOutHandler, MouseWheelHandler {
         perfmon.stopContext(); // updateCircuit
         
         if (developerMode) {
-            int height = 15;
+            int height = 45;
             int increment = 15;
             g.drawString("Framerate: " + CircuitElm.showFormat.format(framerate), 10, height);
             g.drawString("Steprate: " + CircuitElm.showFormat.format(steprate), 10, height += increment);
@@ -1713,8 +1720,14 @@ MouseOutHandler, MouseWheelHandler {
                 g.drawString(splits[x], 10, height + (increment * x));
             }
         }
-        
-        // This should always be the last 
+
+        // Add info about mouse mode in graphics
+        if (mouseModeCheckItem.getState()){
+            if (printableCheckItem.getState()) g.setColor(Color.black);
+            g.drawString(Locale.LS("Mode: ") + classToLabelMap.get(mouseModeStr), 10, 29);
+        }
+
+        // This should always be the last
         // thing called by updateCircuit();
         callUpdateHook();
     }
@@ -5008,7 +5021,8 @@ MouseOutHandler, MouseWheelHandler {
     			dragElm.delete();
     			if (mouseMode == MODE_SELECT || mouseMode == MODE_DRAG_SELECTED)
     				clearSelection();
-			toolbar.setModeLabel(Locale.LS("Press and hold mouse to create circuit element"));
+			if (!mouseModeCheckItem.getState())
+			    toolbar.setModeLabel(Locale.LS("Press and hold mouse to create circuit element"));
 			dragElm = null;
     		}
     		else {
@@ -5683,10 +5697,16 @@ MouseOutHandler, MouseWheelHandler {
     }
     
     void updateToolbar() {
-	if (dragElm != null)
-	    toolbar.setModeLabel(Locale.LS("Drag Mouse"));
-	else
-	    toolbar.setModeLabel(Locale.LS("Mode: ") + classToLabelMap.get(mouseModeStr));
+	if (!mouseModeCheckItem.getState()) {
+	    // Show mode info in toolbar when canvas overlay is disabled
+	    if (dragElm != null)
+		toolbar.setModeLabel(Locale.LS("Drag Mouse"));
+	    else
+		toolbar.setModeLabel(Locale.LS("Mode: ") + classToLabelMap.get(mouseModeStr));
+	} else {
+	    // Clear toolbar label when canvas overlay is showing the mode
+	    toolbar.setModeLabel("");
+	}
 	toolbar.highlightButton(mouseModeStr);
     }
 

--- a/src/com/lushprojects/circuitjs1/client/Toolbar.java
+++ b/src/com/lushprojects/circuitjs1/client/Toolbar.java
@@ -21,6 +21,7 @@ public class Toolbar extends HorizontalPanel {
     private Label modeLabel;
     private HashMap<String, Label> highlightableButtons = new HashMap<>();
     private Label activeButton;  // Currently active button
+    private String SEPARATOR = "<div style=\"height:30px;width:0;border-left:2px solid grey;\"></div>";
 
     Label resistorButton;
 
@@ -35,18 +36,32 @@ public class Toolbar extends HorizontalPanel {
         style.setDisplay(Style.Display.FLEX);
 	setVerticalAlignment(ALIGN_MIDDLE);
 
+	add(createIconButton("doc-new", "New Blank Circuit", new MyCommand("file", "newblankcircuit")));
+	add(createIconButton("folder",  "Open File...", new MyCommand("file", "importfromlocalfile")));
+	if (CirSim.isElectron()) {
+		// Additional conditions are required: "Save" should not be available always.
+		//add(createIconButton("floppy", "Save", new MyCommand("file", "save")));
+		add(createIconButton("floppy", "Save As...", new MyCommand("file", "saveas")));
+	} else {
+		add(createIconButton("floppy", "Save As...", new MyCommand("file", "exportaslocalfile")));
+	}
+	add(new HTML("<sup style=\"margin-left:-12px;\"><strong>+</strong></sup>")); // add symbol to "Save As" icon for the visual difference
+	add(new HTML(SEPARATOR));
 	add(createIconButton("ccw", "Undo", new MyCommand("edit", "undo")));
 	add(createIconButton("cw",  "Redo", new MyCommand("edit", "redo")));
+	add(new HTML(SEPARATOR));
 	add(createIconButton("scissors", "Cut", new MyCommand("edit", "cut")));
 	add(createIconButton("copy", "Copy", new MyCommand("edit", "copy")));
 	add(createIconButton("paste", "Paste", new MyCommand("edit", "paste")));
 	add(createIconButton("clone", "Duplicate", new MyCommand("edit", "duplicate")));
+	add(new HTML(SEPARATOR));
 	add(createIconButton("search", "Find Component...", new MyCommand("edit", "search")));
-
+	add(new HTML(SEPARATOR));
+	add(createIconButton("target", "Centre Circuit", new MyCommand("edit", "centrecircuit")));
 	add(createIconButton("zoom-11", "Zoom 100%", new MyCommand("zoom", "zoom100")));
 	add(createIconButton("zoom-in", "Zoom In", new MyCommand("zoom", "zoomin")));
 	add(createIconButton("zoom-out", "Zoom Out", new MyCommand("zoom", "zoomout")));
-
+	add(new HTML(SEPARATOR));
 	add(createIconButton(wireIcon, "WireElm"));
 	add(resistorButton = createIconButton(resistorIcon, "ResistorElm"));
 	add(createIconButton(groundIcon, "GroundElm"));


### PR DESCRIPTION
## Summary

Rebased version of PR #162 by @SEVA77 onto current master, with conflict resolution.

- Adds file operation buttons to the toolbar (New, Open File, Save As)
- Adds visual separators between toolbar button groups
- Adds "Centre Circuit" button to the toolbar
- Adds "Show Mode" checkbox in Options menu to toggle mode display between toolbar label and canvas overlay

## Conflict Resolution

The original PR #162 removed the toolbar mode label entirely in favor of a canvas overlay. Meanwhile, master enhanced the toolbar mode label with "Drag Mouse" state awareness. This rebased version makes both approaches coexist:

- **"Show Mode" ON** (default): Mode info is drawn on the canvas as an overlay (PR #162's approach). The toolbar label is cleared.
- **"Show Mode" OFF**: Mode info is shown in the toolbar label (master's approach), including the enhanced "Drag Mouse" and "Press and hold mouse..." states.

The "Show Mode" setting persists via localStorage.

## Changes

| File | Change |
|------|--------|
| CirSim.java | Add mouseModeCheckItem field, Options menu checkbox, canvas overlay drawing, conditional toolbar label logic |
| Toolbar.java | Add SEPARATOR div, file operation buttons, Centre Circuit button, separators between groups |

## Test plan

- [ ] Verify file buttons (New, Open, Save As) appear on toolbar and function correctly
- [ ] Verify separators render between button groups
- [ ] Verify "Centre Circuit" button works
- [ ] Toggle "Show Mode" off - verify mode info appears in toolbar
- [ ] Toggle "Show Mode" on - verify mode info appears as canvas overlay
- [ ] Verify Save As button is hidden in Electron builds

Verified: GWT compilation succeeds with gradle compileGwt.

cc @SEVA77 - this is a rebase of your PR #162 onto current master with conflict resolution. Thank you for the original work!

Generated with [Claude Code](https://claude.com/claude-code)
