### PR TITLE
Show circuit filename in title bar for Electron, add auto-centre on resize option

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/CirSim.java
+++ b/src/com/lushprojects/circuitjs1/client/CirSim.java
@@ -220,6 +220,7 @@ MouseOutHandler, MouseWheelHandler {
 
     double minFrameRate = 20;
     boolean adjustTimeStep;
+    boolean centreOnResize;
     boolean developerMode;
     static final int HINT_LC = 1;
     static final int HINT_RC = 2;
@@ -449,6 +450,7 @@ MouseOutHandler, MouseWheelHandler {
 	    currentColor = qp.getValue("currentColor");
 	    mouseModeReq = qp.getValue("mouseMode");
 	    hideInfoBox = qp.getBooleanValue("hideInfoBox", false);
+	    centreOnResize = getOptionFromStorage("centreOnResize", false);
 	} catch (Exception e) { }
 
 	boolean euroSetting = false;
@@ -703,6 +705,8 @@ MouseOutHandler, MouseWheelHandler {
 
 	Window.addResizeHandler(new ResizeHandler() {
 	    public void onResize(ResizeEvent event) {
+		if (centreOnResize)
+		    centreCircuit();
 		repaint();
 	    }
 	});
@@ -836,6 +840,12 @@ MouseOutHandler, MouseWheelHandler {
 	if (startCircuitText != null) {
 	    getSetupList(false);
 	    readCircuit(startCircuitText);
+	    // set title from Electron filename if available (#171)
+	    String fn = getElectronStartCircuitFileName();
+	    if (fn != null && fn.length() > 0) {
+		setCircuitTitle(fn);
+		ExportAsLocalFileDialog.setLastFileName(fn);
+	    }
 	    unsavedChanges = false;
 	} else {
 	    if (stopMessage == null && startCircuitLink!=null) {
@@ -3302,7 +3312,11 @@ MouseOutHandler, MouseWheelHandler {
 
     static native String getElectronStartCircuitText() /*-{
     	return $wnd.startCircuitText;
-    }-*/;    
+    }-*/;
+
+    static native String getElectronStartCircuitFileName() /*-{
+    	return $wnd.startCircuitFileName;
+    }-*/;
     
     void allowSave(boolean b) {
 	if (saveFileItem != null)

--- a/src/com/lushprojects/circuitjs1/client/EditOptions.java
+++ b/src/com/lushprojects/circuitjs1/client/EditOptions.java
@@ -86,6 +86,11 @@ class EditOptions implements Editable {
 		}
 		if (n == 14 && sim.adjustTimeStep)
 		    return new EditInfo("Minimum time step size (s)", sim.minTimeStep, 0, 0);
+		if (n == 15) {
+		    EditInfo ei = new EditInfo("", 0, -1, -1);
+		    ei.checkbox = new Checkbox("Auto-Centre Circuit on Window Resize", sim.centreOnResize);
+		    return ei;
+		}
 
 		return null;
 	}
@@ -169,6 +174,10 @@ class EditOptions implements Editable {
 		}
 		if (n == 14 && ei.value > 0)
 		    sim.minTimeStep = ei.value;
+		if (n == 15) {
+		    sim.centreOnResize = ei.checkbox.getState();
+		    sim.setOptionInStorage("centreOnResize", sim.centreOnResize);
+		}
 	}
 	
 	Color setColor(String name, EditInfo ei, Color def) {


### PR DESCRIPTION
## Summary

Two small, focused fixes for long-standing usability requests:

- **#171 -- Show filename when circuit loaded via Electron**: When CircuitJS1 is opened from the OS file manager (Electron), `readCircuit()` was clearing the title. This adds a `getElectronStartCircuitFileName()` native method to retrieve the filename from Electron's `window.startCircuitFileName` and sets the circuit title + last filename after loading. The "Current Circuit" label and browser title bar now show the filename.

- **#181 -- Auto-centre circuit on window resize**: Adds an "Auto-Centre Circuit on Window Resize" checkbox to Other Options. When enabled, the existing `centreCircuit()` method is called in the window resize handler. The setting persists via localStorage and defaults to off, keeping current behavior unchanged.

## Changes

| File | Change |
|------|--------|
| CirSim.java | Add `centreOnResize` field, load from localStorage, call `centreCircuit()` in resize handler; add `getElectronStartCircuitFileName()` JSNI method; set title after `startCircuitText` load |
| EditOptions.java | Add "Auto-Centre Circuit on Window Resize" checkbox at index 15; persist to localStorage |

## Notes

- The Electron filename fix requires the Electron wrapper to set `window.startCircuitFileName` when opening files. If the variable is not set, behavior is unchanged (graceful fallback).
- Auto-centre is off by default -- no behavior change for existing users.
- Both changes are 24 lines total across 2 files.

## Test plan

- [ ] Open circuit via Electron file manager -- verify filename appears in title bar and "Current Circuit" label
- [ ] Open Other Options -- verify "Auto-Centre Circuit on Window Resize" checkbox appears
- [ ] Enable auto-centre, resize window -- verify circuit re-centres
- [ ] Disable auto-centre, resize window -- verify no auto-centring (current behavior)
- [ ] Reload page -- verify auto-centre setting persists

Verified: GWT compilation succeeds with `gradle compileGwt`.

Generated with [Claude Code](https://claude.com/claude-code)
