### PR TITLE
Fix 6 open issues: zoom, voltage display, arrow keys, relay labels, SRAM hex, subcircuit dialog

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/CirSim.java
+++ b/src/com/lushprojects/circuitjs1/client/CirSim.java
@@ -5065,6 +5065,8 @@ MouseOutHandler, MouseWheelHandler {
     	double val = dy*.01;
     	newScale = Math.max(oldScale+val, .2);
     	newScale = Math.min(newScale, 2.5);
+    	if (newScale == oldScale)
+    	    return;
     	setCircuitScale(newScale, menu);
     }
     
@@ -5611,6 +5613,26 @@ MouseOutHandler, MouseWheelHandler {
     			e.cancel();
     		}
 
+    		if (code==KEY_LEFT || code==KEY_RIGHT || code==KEY_UP || code==KEY_DOWN) {
+    		    int dx = 0, dy = 0;
+    		    if (code == KEY_LEFT)  dx = -gridSize;
+    		    if (code == KEY_RIGHT) dx = gridSize;
+    		    if (code == KEY_UP)    dy = -gridSize;
+    		    if (code == KEY_DOWN)  dy = gridSize;
+    		    boolean hasSel = false;
+    		    for (int i = 0; i != elmList.size(); i++)
+    			if (getElm(i).isSelected()) { hasSel = true; break; }
+    		    if (hasSel) {
+    			pushUndo();
+    			for (int i = 0; i != elmList.size(); i++) {
+    			    CircuitElm ce = getElm(i);
+    			    if (ce.isSelected())
+    				ce.move(dx, dy);
+    			}
+    			needAnalyze();
+    			e.cancel();
+    		    }
+    		}
     		if (e.getNativeEvent().getCtrlKey() || e.getNativeEvent().getMetaKey()) {
     			if (code==KEY_C) {
     				menuPerformed("key", "copy");

--- a/src/com/lushprojects/circuitjs1/client/EditCompositeModelDialog.java
+++ b/src/com/lushprojects/circuitjs1/client/EditCompositeModelDialog.java
@@ -128,10 +128,10 @@ public class EditCompositeModelDialog extends Dialog implements MouseDownHandler
 		Date date = new Date();
 
 		Canvas canvas = Canvas.createIfSupported();
-		canvas.setWidth("400 px");
-		canvas.setHeight("400 px");
-		canvas.setCoordinateSpaceWidth(400);
-		canvas.setCoordinateSpaceHeight(400);
+		canvas.setWidth("600 px");
+		canvas.setHeight("600 px");
+		canvas.setCoordinateSpaceWidth(600);
+		canvas.setCoordinateSpaceHeight(600);
 		vp.add(canvas);
 		CirSim.doTouchHandlers(null, canvas.getCanvasElement());
 		context = canvas.getContext2d();

--- a/src/com/lushprojects/circuitjs1/client/RelayElm.java
+++ b/src/com/lushprojects/circuitjs1/client/RelayElm.java
@@ -186,8 +186,19 @@ class RelayElm extends CircuitElm {
 			 switchCurCount[p]);
 	}
 	
+	// draw NC/NO labels near switch throw contacts
+	g.setColor(whiteColor);
+	g.setFont(unitsFont);
+	for (p = 0; p != poleCount; p++) {
+	    int labelOffset = 8 * dflip;
+	    Point ncPost = swposts[p][1];
+	    Point noPost = swposts[p][2];
+	    g.drawString("NC", ncPost.x + 4, ncPost.y + 4);
+	    g.drawString("NO", noPost.x + 4, noPost.y + 4);
+	}
+
 	coilCurCount = updateDotCount(coilCurrent, coilCurCount);
-	
+
 	if (coilCurCount != 0) {
 	    drawDots(g, coilPosts[0], coilLeads[0], coilCurCount);
 	    drawDots(g, coilLeads[0], coilLeads[1], addCurCount(coilCurCount, currentOffset1));

--- a/src/com/lushprojects/circuitjs1/client/SRAMElm.java
+++ b/src/com/lushprojects/circuitjs1/client/SRAMElm.java
@@ -25,6 +25,7 @@ import com.google.gwt.user.client.ui.Button;
 import com.google.gwt.user.client.ui.TextArea;
 
     class SRAMElm extends ChipElm {
+	static final int FLAG_HEX_DISPLAY = 4;
 	int addressNodes, dataNodes, internalNodes;
 	int addressBits, dataBits;
 	HashMap<Integer, Integer> map;
@@ -128,19 +129,21 @@ import com.google.gwt.user.client.ui.TextArea;
         		s = contentsOverride;
         		contentsOverride = null;
         	} else {
+        	boolean hex = hasFlag(FLAG_HEX_DISPLAY);
         	int i;
         	int maxI = 1<<addressBits;
         	for (i = 0; i < maxI; i++) {
         	    Integer val = map.get(i);
         	    if (val == null)
         		continue;
-    	    	    s += i + ": " + val;
+    	    	    s += (hex ? Integer.toHexString(i).toUpperCase() : "" + i) + ": " +
+    	    	         (hex ? toHex(val) : "" + val);
     	    	    int ct = 1;
     	    	    while (true) {
     	    		val = map.get(++i);
     	    		if (val == null)
     	    		    break;
-    	    		s += " " + val;
+    	    		s += " " + (hex ? toHex(val) : "" + val);
     	    		if (++ct == 8)
     	    		    break;
     	    	    }
@@ -151,7 +154,12 @@ import com.google.gwt.user.client.ui.TextArea;
     	    	ei.textArea.setText(s);
     	    	return ei;
             }
-            if (n == 3 && SRAMLoadFile.isSupported()) {
+            if (n == 3) {
+            	EditInfo ei = new EditInfo("", 0, -1, -1);
+            	ei.checkbox = new Checkbox("Hex Display", hasFlag(FLAG_HEX_DISPLAY));
+            	return ei;
+            }
+            if (n == 4 && SRAMLoadFile.isSupported()) {
             	EditInfo ei = new EditInfo("", 0, -1, -1);
             	ei.loadFile = new SRAMLoadFile();
             	ei.button = new Button("Load Contents From File");
@@ -161,11 +169,18 @@ import com.google.gwt.user.client.ui.TextArea;
 	    return super.getChipEditInfo(n);
 	}
 	
+	String toHex(int val) {
+	    String h = Integer.toHexString(val & 0xFF).toUpperCase();
+	    return h.length() < 2 ? "0" + h : h;
+	}
+
 	int parseNumber(String str) {
 	    if (str.startsWith("0x"))
 		return Integer.parseInt(str.substring(2), 16);
 	    if (str.startsWith("0b"))
 		return Integer.parseInt(str.substring(2), 2);
+	    if (hasFlag(FLAG_HEX_DISPLAY))
+		return Integer.parseInt(str, 16);
 	    return Integer.parseInt(str);
 	}
 
@@ -199,6 +214,8 @@ import com.google.gwt.user.client.ui.TextArea;
 		    } catch (Exception e) {}
 		}
 	    }
+	    if (n == 3)
+		flags = ei.changeFlag(flags, FLAG_HEX_DISPLAY);
 	}
 	int getVoltageSourceCount() { return dataBits; }
 	int getInternalNodeCount() { return dataBits; }

--- a/src/com/lushprojects/circuitjs1/client/VoltageElm.java
+++ b/src/com/lushprojects/circuitjs1/client/VoltageElm.java
@@ -203,7 +203,8 @@ class VoltageElm extends CircuitElm {
 	    g.drawString(inds, plusPoint.x-w/2, plusPoint.y);
 	}
 	if (dx == 0 || dy == 0) {
-	    boolean showV = (flags & FLAG_SHOW_VOLTAGE) != 0;
+	    boolean showV = (flags & FLAG_SHOW_VOLTAGE) != 0 ||
+			    (sim.showValuesCheckItem.getState() && waveform == WF_DC);
 	    boolean showF = sim.showValuesCheckItem.getState() &&
 			    waveform != WF_DC && waveform != WF_NOISE;
 	    String s = null;


### PR DESCRIPTION
## Summary

Six independent easy fixes for open issues, all verified with `gradle compileGwt`:

### 1. Fix #210 — Zoom stutter at min/max scale
When zoom is clamped at the minimum (0.2) or maximum (2.5) scale, the translation was still being recalculated, causing the view to stutter toward the cursor. Now returns early if the scale didn't actually change.

### 2. Fix #206 — Show voltage value next to DC voltage sources
DC voltage sources now display their voltage value (e.g., "5V") next to the component when "Show Values" is enabled in the Options menu, matching the behavior of resistors, capacitors, and inductors. The existing per-element "Show Voltage" checkbox also continues to work.

### 3. Fix #180 — Arrow key movement of selected items
Selected circuit elements can now be moved using arrow keys (Left/Right/Up/Down), stepping by one grid unit (16px or 8px with small grid). This makes precise alignment much easier on larger schematics without needing to zoom in.

### 4. Fix #80 — Relay NC/NO contact labels
Relay switch contacts now display "NC" (Normally Closed) and "NO" (Normally Open) labels near the throw positions, making it clear at a glance which contact is which without opening the properties dialog.

### 5. Fix #183 — SRAM hex display option
Adds a "Hex Display" checkbox to the SRAM edit dialog. When enabled, memory contents are displayed as uppercase two-character hex values (e.g., `0: 7E 0A FF`) instead of decimal. Input parsing also switches to hex mode, and addresses are shown in hex.

### 6. Fix #140 — Subcircuit pin layout dialog too small
Enlarged the "Edit Subcircuit Pin Layout" dialog canvas from 400x400 to 600x600 pixels, making pin labels more legible when creating subcircuits with many nodes.

## Changes at a glance

| File | Lines | What |
|------|-------|------|
| `CirSim.java` | +22 | Zoom clamp early return + arrow key handlers |
| `VoltageElm.java` | +2/-1 | DC voltage value display via showValuesCheckItem |
| `RelayElm.java` | +12/-1 | NC/NO text labels on switch contacts |
| `SRAMElm.java` | +20/-3 | Hex display flag, toHex helper, checkbox, hex-aware parsing |
| `EditCompositeModelDialog.java` | +4/-4 | Canvas 400→600 |

**Total: 60 additions, 9 deletions across 5 files.**

## Test plan

- [ ] Zoom in/out to min/max scale and verify no view stutter
- [ ] Place a DC voltage source, enable Show Values, verify voltage is displayed
- [ ] Select elements, press arrow keys to verify grid-step movement
- [ ] Place a relay, verify NC/NO labels visible on contacts
- [ ] Place SRAM, toggle Hex Display checkbox, verify hex formatting
- [ ] Create a subcircuit with many pins, verify dialog is larger and more legible

🤖 Generated with [Claude Code](https://claude.com/claude-code)
