### PR TITLE
Fix 4 issues: hex display, wattmeter avg, switch flip sync, iframe CSS

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/DecimalDisplayElm.java
+++ b/src/com/lushprojects/circuitjs1/client/DecimalDisplayElm.java
@@ -21,7 +21,8 @@ package com.lushprojects.circuitjs1.client;
 
 class DecimalDisplayElm extends ChipElm {
     int bitCount;
-    
+    int displayMode; // 0=decimal, 1=hex, 2=octal, 3=binary
+
     public DecimalDisplayElm(int xx, int yy) {
 	super(xx, yy);
 	bitCount = 4;
@@ -33,6 +34,7 @@ class DecimalDisplayElm extends ChipElm {
 	bitCount = 4;
 	try {
 	    bitCount = Integer.parseInt(st.nextToken());
+	    displayMode = Integer.parseInt(st.nextToken());
 	} catch (Exception e) {}
 	setupPins();
     }
@@ -53,13 +55,19 @@ class DecimalDisplayElm extends ChipElm {
         for (i = 0; i != bitCount; i++)
             if (pins[i].value)
         	value |= 1<<i;
-        String str = String.valueOf(value);
+        String str;
+        switch (displayMode) {
+        case 1:  str = Integer.toHexString(value).toUpperCase(); break;
+        case 2:  str = Integer.toOctalString(value); break;
+        case 3:  str = Integer.toBinaryString(value); break;
+        default: str = String.valueOf(value); break;
+        }
         int w=(int)g.context.measureText(str).getWidth();
         g.drawString(str, xl+5*csize-w/2, yl);
         g.restore();
     }
     
-    String dump() { return super.dump() + " " + bitCount; }
+    String dump() { return super.dump() + " " + bitCount + " " + displayMode; }
     
     void setupPins() {
 	sizeX = 3;
@@ -77,6 +85,16 @@ class DecimalDisplayElm extends ChipElm {
         if (n == 0)
             return new EditInfo("# of Bits", bitCount, 1, 8).
                 setDimensionless();
+        if (n == 1) {
+            EditInfo ei = new EditInfo("Display Mode", 0, -1, -1);
+            ei.choice = new Choice();
+            ei.choice.add("Decimal");
+            ei.choice.add("Hexadecimal");
+            ei.choice.add("Octal");
+            ei.choice.add("Binary");
+            ei.choice.select(displayMode);
+            return ei;
+        }
         return super.getChipEditInfo(n);
     }
     public void setChipEditValue(int n, EditInfo ei) {
@@ -86,6 +104,8 @@ class DecimalDisplayElm extends ChipElm {
             setPoints();
             return;
         }
+        if (n == 1)
+            displayMode = ei.choice.getSelectedIndex();
         super.setChipEditValue(n, ei);
     }
 

--- a/src/com/lushprojects/circuitjs1/client/Switch2Elm.java
+++ b/src/com/lushprojects/circuitjs1/client/Switch2Elm.java
@@ -25,6 +25,7 @@ package com.lushprojects.circuitjs1.client;
 	int link;
 	int throwCount;
 	static final int FLAG_CENTER_OFF = 1;
+	boolean positionFlipped; // tracks runtime flip state for sync
 	
 	public Switch2Elm(int xx, int yy) {
 	    super(xx, yy, false);
@@ -136,8 +137,13 @@ package com.lushprojects.circuitjs1.client;
 		    Object o = sim.elmList.elementAt(i);
 		    if (o instanceof Switch2Elm) {
 			Switch2Elm s2 = (Switch2Elm) o;
-			if (s2.link == link && position < s2.posCount)
-			    s2.position = position;
+			if (s2.link == link) {
+			    int pos = position;
+			    if (s2.positionFlipped != this.positionFlipped)
+				pos = posCount - 1 - pos;
+			    if (pos < s2.posCount)
+				s2.position = pos;
+			}
 		    }
 		}
 	    }
@@ -201,16 +207,19 @@ package com.lushprojects.circuitjs1.client;
 	void flipX(int c2, int count) {
 	    super.flipX(c2, count);
 	    position = posCount-1-position;
-	}   
-		 
-	void flipY(int c2, int count) { 
+	    positionFlipped = !positionFlipped;
+	}
+
+	void flipY(int c2, int count) {
 	    super.flipY(c2, count);
 	    position = posCount-1-position;
+	    positionFlipped = !positionFlipped;
 	}
 
 	void flipXY(int c2, int count) {
 	    super.flipXY(c2, count);
 	    position = posCount-1-position;
+	    positionFlipped = !positionFlipped;
 	}       
 
     }

--- a/src/com/lushprojects/circuitjs1/client/WattmeterElm.java
+++ b/src/com/lushprojects/circuitjs1/client/WattmeterElm.java
@@ -24,6 +24,13 @@ class WattmeterElm extends CircuitElm {
     int voltSources[];
     double currents[];
     double curcounts[];
+    int meter; // 0=instantaneous, 1=average
+    final int PM_INST = 0;
+    final int PM_AVG = 1;
+    double avgPower, totalPower, count;
+    int zerocount;
+    double maxP, lastMaxP, minP, lastMinP;
+    boolean increasingP = true, decreasingP = true;
 
     public WattmeterElm(int xx, int yy) {
 	super(xx, yy);
@@ -33,6 +40,9 @@ class WattmeterElm extends CircuitElm {
 	    StringTokenizer st) {
 	super(xa, ya, xb, yb, f);
 	width = Integer.parseInt(st.nextToken());
+	try {
+	    meter = Integer.parseInt(st.nextToken());
+	} catch (Exception e) {}
 	setup();
     }
 
@@ -42,7 +52,7 @@ class WattmeterElm extends CircuitElm {
 	curcounts = new double[2];
     }
 
-    String dump() { return super.dump() + " " + width; }
+    String dump() { return super.dump() + " " + width + " " + meter; }
 
     int getVoltageSourceCount() { return 2; }
     int getDumpType() { return 420; }
@@ -119,6 +129,55 @@ class WattmeterElm extends CircuitElm {
 	voltSources[j] = vs;
     }
 
+    void stepFinished() {
+	double p = getPower();
+	count++;
+	totalPower += p;
+	if (p > maxP && increasingP) {
+	    maxP = p;
+	    increasingP = true;
+	    decreasingP = false;
+	}
+	if (p < maxP && increasingP) {
+	    lastMaxP = maxP;
+	    minP = p;
+	    increasingP = false;
+	    decreasingP = true;
+	    avgPower = totalPower / count;
+	    if (Double.isNaN(avgPower))
+		avgPower = 0;
+	    count = 0;
+	    totalPower = 0;
+	}
+	if (p < minP && decreasingP) {
+	    minP = p;
+	    increasingP = false;
+	    decreasingP = true;
+	}
+	if (p > minP && decreasingP) {
+	    lastMinP = minP;
+	    maxP = p;
+	    increasingP = true;
+	    decreasingP = false;
+	    avgPower = totalPower / count;
+	    if (Double.isNaN(avgPower))
+		avgPower = 0;
+	    count = 0;
+	    totalPower = 0;
+	}
+	if (p == 0) {
+	    zerocount++;
+	    if (zerocount > 5) {
+		totalPower = 0;
+		avgPower = 0;
+		maxP = 0;
+		minP = 0;
+	    }
+	} else {
+	    zerocount = 0;
+	}
+    }
+
     void draw(Graphics g) {
 	int i;
 	for (i = 0; i != 2; i++)
@@ -130,14 +189,18 @@ class WattmeterElm extends CircuitElm {
 	    drawDots(g, posts[i], inner[i], curcounts[i/2]*flip);
 	    flip *= -1;
 	}
-	
+
         g.setColor(needsHighlight() ? selectColor : lightGrayColor);
 	drawThickPolygon(g, rectPointsX, rectPointsY, 4);
-	
+
 	setBbox(posts[0].x, posts[0].y, posts[3].x, posts[3].y);
 	drawPosts(g);
 
-	String str = getUnitText(getPower(), "W");
+	String str;
+	switch (meter) {
+	case PM_AVG:  str = getUnitText(avgPower, "W(avg)"); break;
+	default:      str = getUnitText(getPower(), "W"); break;
+	}
 	g.save();
 	int fsize = 15;
 	int w;
@@ -174,10 +237,29 @@ class WattmeterElm extends CircuitElm {
 	arr[0] = "wattmeter";
 	getBasicInfo(arr);
 	arr[3] = "P = " + getUnitText(getPower(), "W");
+	if (meter == PM_AVG)
+	    arr[4] = "Pavg = " + getUnitText(avgPower, "W");
     }
     boolean canViewInScope() { return true; }
     double getCurrent() { return currents[1]; }
     double getVoltageDiff() { return volts[2]-volts[0]; }
     boolean canFlipX() { return false; }
     boolean canFlipY() { return false; }
+
+    public EditInfo getEditInfo(int n) {
+	if (n == 0) {
+	    EditInfo ei = new EditInfo("Value", 0, -1, -1);
+	    ei.choice = new Choice();
+	    ei.choice.add("Instantaneous");
+	    ei.choice.add("Average");
+	    ei.choice.select(meter);
+	    return ei;
+	}
+	return null;
+    }
+
+    public void setEditValue(int n, EditInfo ei) {
+	if (n == 0)
+	    meter = ei.choice.getSelectedIndex();
+    }
 }

--- a/war/circuitjs.html
+++ b/war/circuitjs.html
@@ -11,6 +11,13 @@
     <title></title>
 
 <style>
+html, body {
+	height: 100%;
+	width: 100%;
+	margin: 0;
+	padding: 0;
+	overflow: hidden;
+}
 .disabled {
 	color: lightgray
 }


### PR DESCRIPTION
## Summary

- **Fixes #178**: Adds display mode dropdown (Decimal / Hexadecimal / Octal / Binary) to the decimal display element. Uppercase hex output as requested. Backward-compatible serialization.
- **Fixes #129**: Adds average power mode to the wattmeter, following AmmeterElm's cycle-detection pattern. Dropdown to select Instantaneous or Average display. Average resets per waveform cycle.
- **Fixes #175**: Tracks flip state in Switch2Elm so linked switch group sync accounts for relative flip orientation. When flipped and non-flipped switches share a link, the position value is inverted during sync to maintain visual consistency.
- **Fixes #113**: Adds `html, body { height: 100%; width: 100%; margin: 0; padding: 0; overflow: hidden; }` CSS rules to `circuitjs.html` so GWT's `RootLayoutPanel` sizes correctly when embedded in an `<iframe>` (Chrome-specific issue).

## Changes at a glance

| File | Lines | What |
|------|-------|------|
| `DecimalDisplayElm.java` | +20 | `displayMode` field, Choice dropdown, mode-aware formatting |
| `WattmeterElm.java` | +82 | `stepFinished()` cycle detection, `meter` mode, edit dialog |
| `Switch2Elm.java` | +7 | `positionFlipped` flag, flip-aware sync in `toggle()` |
| `circuitjs.html` | +7 | `html, body` sizing rules for iframe embedding |

## Test plan

- [ ] Place decimal display, verify default decimal mode, switch to Hex/Octal/Binary and verify output
- [ ] Save/load circuit with non-default display mode, verify mode persists
- [ ] Place wattmeter in AC circuit, switch to Average mode, verify stable average reading
- [ ] Save/load circuit with average wattmeter, verify mode persists
- [ ] Place 4 linked SPDT switches (same Switch Group), flip 2 of them, toggle one and verify all sync correctly
- [ ] Embed `circuitjs.html` in an `<iframe>` in Chrome, verify canvas renders on first load

🤖 Generated with [Claude Code](https://claude.com/claude-code)