### PR TITLE
Scope horizontal scale, auto DC on reset, gyrator element

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/CirSim.java
+++ b/src/com/lushprojects/circuitjs1/client/CirSim.java
@@ -220,6 +220,7 @@ MouseOutHandler, MouseWheelHandler {
 
     double minFrameRate = 20;
     boolean adjustTimeStep;
+    boolean autoDCOnReset;
     boolean developerMode;
     static final int HINT_LC = 1;
     static final int HINT_RC = 2;
@@ -933,6 +934,10 @@ MouseOutHandler, MouseWheelHandler {
 	    Storage stor = Storage.getLocalStorageIfSupported();
 	    wheelSensitivity = Double.parseDouble(stor.getItem("wheelSensitivity"));
 	} catch (Exception e) {}
+	try {
+	    Storage stor = Storage.getLocalStorageIfSupported();
+	    autoDCOnReset = "true".equals(stor.getItem("autoDCOnReset"));
+	} catch (Exception e) {}
     }
 
     MenuItem menuItemWithShortcut(String icon, String text, String shortcut, MyCommand cmd) {
@@ -1119,6 +1124,7 @@ MouseOutHandler, MouseWheelHandler {
     	passMenuBar.addItem(getClassCheckItem(Locale.LS("Add Transformer"), "TransformerElm"));
     	passMenuBar.addItem(getClassCheckItem(Locale.LS("Add Tapped Transformer"), "TappedTransformerElm"));
     	passMenuBar.addItem(getClassCheckItem(Locale.LS("Add Custom Transformer"), "CustomTransformerElm"));
+    	passMenuBar.addItem(getClassCheckItem(Locale.LS("Add Gyrator"), "GyratorElm"));
     	passMenuBar.addItem(getClassCheckItem(Locale.LS("Add Transmission Line"), "TransLineElm"));
     	passMenuBar.addItem(getClassCheckItem(Locale.LS("Add Relay"), "RelayElm"));
     	passMenuBar.addItem(getClassCheckItem(Locale.LS("Add Relay Coil"), "RelayCoilElm"));
@@ -3242,6 +3248,8 @@ MouseOutHandler, MouseWheelHandler {
     public void resetAction(){
     	int i;
     	analyzeFlag = true;
+    	if (autoDCOnReset)
+    	    dcAnalysisFlag = true;
     	if (t == 0)
     	    setSimRunning(true);
     	t = timeStepAccum = 0;
@@ -5969,6 +5977,7 @@ MouseOutHandler, MouseWheelHandler {
     	case 428: return new MotorProtectionSwitchElm(x1, y1, x2, y2, f, st);
     	case 429: return new DPDTSwitchElm(x1, y1, x2, y2, f, st);
     	case 430: return new CrossSwitchElm(x1, y1, x2, y2, f, st);
+    	case 433: return new GyratorElm(x1, y1, x2, y2, f, st);
         }
     	return null;
     }
@@ -6245,6 +6254,8 @@ MouseOutHandler, MouseWheelHandler {
 		return (CircuitElm) new DPDTSwitchElm(x1, y1);
     	if (n=="CrossSwitchElm")
 		return (CircuitElm) new CrossSwitchElm(x1, y1);
+    	if (n=="GyratorElm")
+		return (CircuitElm) new GyratorElm(x1, y1);
     	
     	// handle CustomCompositeElm:modelname
     	if (n.startsWith("CustomCompositeElm:")) {

--- a/src/com/lushprojects/circuitjs1/client/EditOptions.java
+++ b/src/com/lushprojects/circuitjs1/client/EditOptions.java
@@ -86,6 +86,11 @@ class EditOptions implements Editable {
 		}
 		if (n == 14 && sim.adjustTimeStep)
 		    return new EditInfo("Minimum time step size (s)", sim.minTimeStep, 0, 0);
+		if (n == 15) {
+		    EditInfo ei = new EditInfo("", 0, -1, -1);
+		    ei.checkbox = new Checkbox("Auto-Run DC Operating Point on Reset", sim.autoDCOnReset);
+		    return ei;
+		}
 
 		return null;
 	}
@@ -169,6 +174,12 @@ class EditOptions implements Editable {
 		}
 		if (n == 14 && ei.value > 0)
 		    sim.minTimeStep = ei.value;
+		if (n == 15) {
+		    sim.autoDCOnReset = ei.checkbox.getState();
+		    Storage stor = Storage.getLocalStorageIfSupported();
+		    if (stor != null)
+			stor.setItem("autoDCOnReset", sim.autoDCOnReset ? "true" : "false");
+		}
 	}
 	
 	Color setColor(String name, EditInfo ei, Color def) {

--- a/src/com/lushprojects/circuitjs1/client/GyratorElm.java
+++ b/src/com/lushprojects/circuitjs1/client/GyratorElm.java
@@ -1,0 +1,219 @@
+/*
+    Copyright (C) Paul Falstad and Iain Sharp
+
+    This file is part of CircuitJS1.
+
+    CircuitJS1 is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    CircuitJS1 is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with CircuitJS1.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package com.lushprojects.circuitjs1.client;
+
+class GyratorElm extends CircuitElm {
+    double gyrResistance;
+    Point ptEnds[], ptCoil[], ptCore[];
+    double current[];
+    double curcount[];
+    int width, flip;
+    public static final int FLAG_VERTICAL = 8;
+    public static final int FLAG_FLIP = 16;
+
+    public GyratorElm(int xx, int yy) {
+	super(xx, yy);
+	gyrResistance = 1000;
+	width = 32;
+	noDiagonal = true;
+	current = new double[2];
+	curcount = new double[2];
+    }
+
+    public GyratorElm(int xa, int ya, int xb, int yb, int f,
+		      StringTokenizer st) {
+	super(xa, ya, xb, yb, f);
+	if (hasFlag(FLAG_VERTICAL))
+	    width = -max(32, abs(xb-xa));
+	else
+	    width = max(32, abs(yb-ya));
+	gyrResistance = new Double(st.nextToken()).doubleValue();
+	current = new double[2];
+	curcount = new double[2];
+	try {
+	    current[0] = new Double(st.nextToken()).doubleValue();
+	    current[1] = new Double(st.nextToken()).doubleValue();
+	} catch (Exception e) {}
+	noDiagonal = true;
+    }
+
+    void drag(int xx, int yy) {
+	xx = sim.snapGrid(xx);
+	yy = sim.snapGrid(yy);
+	if (abs(xx-x) > abs(yy-y))
+	    flags &= ~FLAG_VERTICAL;
+	else
+	    flags |= FLAG_VERTICAL;
+	if (hasFlag(FLAG_VERTICAL))
+	    width = -max(32, abs(xx-x));
+	else
+	    width = max(32, abs(yy-y));
+	if (xx == x)
+	    yy = y;
+	x2 = xx; y2 = yy;
+	setPoints();
+    }
+
+    int getDumpType() { return 433; }
+
+    String dump() {
+	return super.dump() + " " + gyrResistance + " " +
+	    current[0] + " " + current[1];
+    }
+
+    void draw(Graphics g) {
+	int i;
+	for (i = 0; i != 4; i++) {
+	    setVoltageColor(g, volts[i]);
+	    drawThickLine(g, ptEnds[i], ptCoil[i]);
+	}
+	// draw two boxes for the two ports
+	for (i = 0; i != 2; i++) {
+	    setPowerColor(g, current[i]*(volts[i]-volts[i+2]));
+	    drawThickLine(g, ptCoil[i], ptCoil[i+2]);
+	}
+	// draw core lines
+	g.setColor(needsHighlight() ? selectColor : lightGrayColor);
+	for (i = 0; i != 2; i++) {
+	    drawThickLine(g, ptCore[i], ptCore[i+2]);
+	    curcount[i] = updateDotCount(current[i], curcount[i]);
+	}
+	for (i = 0; i != 2; i++) {
+	    drawDots(g, ptEnds[i], ptCoil[i], curcount[i]);
+	    drawDots(g, ptCoil[i], ptCoil[i+2], curcount[i]);
+	    drawDots(g, ptEnds[i+2], ptCoil[i+2], -curcount[i]);
+	}
+
+	drawPosts(g);
+	setBbox(ptEnds[0], ptEnds[3], 0);
+    }
+
+    void setPoints() {
+	super.setPoints();
+	if (hasFlag(FLAG_VERTICAL))
+	    point2.x = point1.x;
+	else
+	    point2.y = point1.y;
+	ptEnds = newPointArray(4);
+	ptCoil = newPointArray(4);
+	ptCore = newPointArray(4);
+	ptEnds[0] = point1;
+	ptEnds[1] = point2;
+	flip = hasFlag(FLAG_FLIP) ? -1 : 1;
+	interpPoint(point1, point2, ptEnds[2], 0, -dsign*width*flip);
+	interpPoint(point1, point2, ptEnds[3], 1, -dsign*width*flip);
+	double ce = .5-12/dn;
+	double cd = .5-2/dn;
+	int i;
+	for (i = 0; i != 4; i += 2) {
+	    interpPoint(ptEnds[i], ptEnds[i+1], ptCoil[i],   ce);
+	    interpPoint(ptEnds[i], ptEnds[i+1], ptCoil[i+1], 1-ce);
+	    interpPoint(ptEnds[i], ptEnds[i+1], ptCore[i],   cd);
+	    interpPoint(ptEnds[i], ptEnds[i+1], ptCore[i+1], 1-cd);
+	}
+    }
+
+    Point getPost(int n) {
+	return ptEnds[n];
+    }
+
+    int getPostCount() { return 4; }
+
+    void reset() {
+	current[0] = current[1] = volts[0] = volts[1] = volts[2] = volts[3] = 0;
+	curcount[0] = curcount[1] = 0;
+    }
+
+    // Gyrator equations (admittance form):
+    //   I1 = G * V2   (current into port 1 = conductance * voltage across port 2)
+    //   I2 = -G * V1  (current into port 2 = -conductance * voltage across port 1)
+    // where G = 1/R (gyration conductance)
+    //
+    // This is a linear, memoryless element -- no time-stepping needed.
+    void stamp() {
+	double g = 1.0 / gyrResistance;
+	// port 1 (nodes 0,2): current proportional to port 2 voltage (nodes 1,3)
+	sim.stampVCCurrentSource(nodes[0], nodes[2], nodes[1], nodes[3], g);
+	// port 2 (nodes 1,3): current proportional to -port 1 voltage (nodes 0,2)
+	sim.stampVCCurrentSource(nodes[1], nodes[3], nodes[0], nodes[2], -g);
+    }
+
+    void calculateCurrent() {
+	double g = 1.0 / gyrResistance;
+	double v1 = volts[0] - volts[2];
+	double v2 = volts[1] - volts[3];
+	current[0] = g * v2;
+	current[1] = -g * v1;
+    }
+
+    @Override double getCurrentIntoNode(int n) {
+	if (n < 2)
+	    return -current[n];
+	return current[n-2];
+    }
+
+    boolean getConnection(int n1, int n2) {
+	// port 1 terminals connect to each other, port 2 terminals connect to each other
+	// but port 1 and port 2 are not directly connected (coupled via VCCS)
+	if (comparePair(n1, n2, 0, 2))
+	    return true;
+	if (comparePair(n1, n2, 1, 3))
+	    return true;
+	return false;
+    }
+
+    void getInfo(String arr[]) {
+	arr[0] = "gyrator";
+	arr[1] = "R = " + getUnitText(gyrResistance, "\u2126");
+	arr[2] = "Vd1 = " + getVoltageText(volts[0]-volts[2]);
+	arr[3] = "Vd2 = " + getVoltageText(volts[1]-volts[3]);
+	arr[4] = "I1 = " + getCurrentText(current[0]);
+	arr[5] = "I2 = " + getCurrentText(current[1]);
+    }
+
+    public EditInfo getEditInfo(int n) {
+	if (n == 0)
+	    return new EditInfo("Gyration Resistance (\u2126)", gyrResistance, 1, 0);
+	return null;
+    }
+
+    public void setEditValue(int n, EditInfo ei) {
+	if (n == 0 && ei.value > 0)
+	    gyrResistance = ei.value;
+    }
+
+    void flipX(int c2, int count) {
+	if (hasFlag(FLAG_VERTICAL))
+	    flags ^= FLAG_FLIP;
+	super.flipX(c2, count);
+    }
+
+    void flipY(int c2, int count) {
+	if (!hasFlag(FLAG_VERTICAL))
+	    flags ^= FLAG_FLIP;
+	super.flipY(c2, count);
+    }
+
+    void flipXY(int xmy, int count) {
+	flags ^= FLAG_VERTICAL;
+	width *= -1;
+	super.flipXY(xmy, count);
+    }
+}

--- a/src/com/lushprojects/circuitjs1/client/Scope.java
+++ b/src/com/lushprojects/circuitjs1/client/Scope.java
@@ -1743,8 +1743,8 @@ class Scope {
     void setSpeed(int sp) {
 	if (sp < 1)
 	    sp = 1;
-	if (sp > 1024)
-	    sp = 1024;
+	if (sp > 8192)
+	    sp = 8192;
 	speed = sp;
 	resetGraph();
     }
@@ -1762,7 +1762,7 @@ class Scope {
     }
 
     void slowDown() {
-	if (speed < 1024)
+	if (speed < 8192)
 	    speed *= 2;
     	resetGraph();
     }

--- a/src/com/lushprojects/circuitjs1/client/ScopePropertiesDialog.java
+++ b/src/com/lushprojects/circuitjs1/client/ScopePropertiesDialog.java
@@ -367,7 +367,7 @@ labelledGridManager gridLabels;
 		hScaleGrid = new Grid(2,4);
 		hScaleLabel = new expandingLabel(Locale.LS("Horizontal Scale"), displayScales);
 		hScaleGrid.setWidget(0, 0, hScaleLabel.p);
-		speedBar = new Scrollbar(Scrollbar.HORIZONTAL, 2, 1, 0, 11, new Command() {
+		speedBar = new Scrollbar(Scrollbar.HORIZONTAL, 5, 1, 0, 14, new Command() {
 		    public void execute() {
 			scrollbarChanged();
 		    }
@@ -540,7 +540,7 @@ labelledGridManager gridLabels;
 	
 	
 	void scrollbarChanged() {
-	    int newsp = (int)Math.pow(2,  10-speedBar.getValue());
+	    int newsp = (int)Math.pow(2,  13-speedBar.getValue());
 	    CirSim.console("changed " + scope.speed + " " + newsp + " " + speedBar.getValue());
 	    if (scope.speed != newsp)
 		scope.setSpeed(newsp);
@@ -551,7 +551,7 @@ labelledGridManager gridLabels;
 	    vModep.setVisible(vScaleLabel.expanded);
 	    gridLabels.updateRowVisibility();
 	    hScaleGrid.getRowFormatter().setVisible(1, hScaleLabel.expanded);
-	    speedBar.setValue(10-(int)Math.round(Math.log(scope.speed)/Math.log(2)));
+	    speedBar.setValue(13-(int)Math.round(Math.log(scope.speed)/Math.log(2)));
 	    if (voltageBox != null) {
 		voltageBox.setValue(scope.showV && !scope.showingValue(Scope.VAL_POWER));
 		currentBox.setValue(scope.showI && !scope.showingValue(Scope.VAL_POWER));


### PR DESCRIPTION
## Summary
- **Fixes #192**: Extends scope horizontal scale range from 1-1024 to 1-8192, adding 3 more zoomed-out positions for viewing slower waveforms (sub-Hz). For sub-100µs resolution, the simulation timestep can be reduced in Other Options.
- **Fixes #195**: Adds "Auto-Run DC Operating Point on Reset" checkbox to Other Options dialog. When enabled, every reset automatically runs DC analysis first, giving circuits proper initial conditions. Setting persists in localStorage.
- **Fixes #170**: New Gyrator element — a 4-terminal impedance inverter that converts capacitance to inductance and vice versa. Uses VCCS stamps (linear, memoryless — no time-stepping needed). Configurable gyration resistance. Follows TransformerElm visual layout. Dump type 433.

## Changes
- `Scope.java` — extended max speed from 1024 to 8192, updated `setSpeed()` and `slowDown()` bounds
- `ScopePropertiesDialog.java` — extended scrollbar range from 0-10 to 0-13, updated exponent formula
- `CirSim.java` — added `autoDCOnReset` field, localStorage load, `resetAction()` integration, gyrator menu item + registration (dump type 433, name constructor)
- `EditOptions.java` — added checkbox at position n=15, localStorage persistence
- `GyratorElm.java` — new file, 219 lines. Linear 2-port element: I1 = V2/R, I2 = -V1/R

## Test plan
- [ ] Open scope properties, verify horizontal scale scrollbar extends further (3 more zoomed-out stops)
- [ ] Set a slow-frequency source, verify the new range shows more time per division
- [ ] Enable "Auto-Run DC Operating Point on Reset" in Other Options
- [ ] Reset circuit, verify DC operating point is computed before simulation runs
- [ ] Verify setting persists across page reloads
- [ ] Place a Gyrator from Passive Components menu
- [ ] Connect a capacitor on one port — verify it behaves as an inductor on the other port
- [ ] Edit gyration resistance in properties dialog
- [ ] Save/load circuit with gyrator, verify dump type 433 round-trips correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)