### PR TITLE
Add MOSFET channel-length modulation and scope trail persistence

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/JfetElm.java
+++ b/src/com/lushprojects/circuitjs1/client/JfetElm.java
@@ -137,7 +137,7 @@ class JfetElm extends MosfetElm {
 	    getFetInfo(arr, "JFET");
 	}
         public EditInfo getEditInfo(int n) {
-            if (n < 2)
+            if (n < 3)
         	return super.getEditInfo(n);
             return null;
         }

--- a/src/com/lushprojects/circuitjs1/client/MosfetElm.java
+++ b/src/com/lushprojects/circuitjs1/client/MosfetElm.java
@@ -36,6 +36,8 @@ class MosfetElm extends CircuitElm {
 	double vt;
 	// beta = 1/(RdsON*(Vgs-Vt))
 	double beta;
+	// channel-length modulation parameter (1/V), 0 = ideal
+	double lambda;
 	static int globalFlags;
 	Diode diodeB1, diodeB2;
 	double diodeCurrent1, diodeCurrent2, bodyCurrent;
@@ -64,6 +66,7 @@ class MosfetElm extends CircuitElm {
 	    try {
 		vt = new Double(st.nextToken()).doubleValue();
 		beta = new Double(st.nextToken()).doubleValue();
+		lambda = new Double(st.nextToken()).doubleValue();
 	    } catch (Exception e) {}
 	    globalFlags = flags & (FLAGS_GLOBAL);
 	    allocNodes(); // make sure volts[] has the right number of elements when hasBodyTerminal() is true 
@@ -102,7 +105,7 @@ class MosfetElm extends CircuitElm {
 		volts[bodyTerminal] = 0;
 	}
 	String dump() {
-	    return super.dump() + " " + vt + " " + beta;
+	    return super.dump() + " " + vt + " " + beta + " " + lambda;
 	}
 	int getDumpType() { return 'f'; }
 	final int hs = 16;
@@ -396,11 +399,14 @@ class MosfetElm extends CircuitElm {
 		Gds = beta*(vgs-vds-vt);
 		mode = 1;
 	    } else {
-		// saturation; Gds = 0
-		gm  = beta*(vgs-vt);
+		// saturation; Gds from channel-length modulation
+		double vgs_vt = vgs-vt;
+		gm  = beta*vgs_vt*(1+lambda*vds);
+		ids = .5*beta*vgs_vt*vgs_vt*(1+lambda*vds);
+		Gds = .5*beta*vgs_vt*vgs_vt*lambda;
 		// use very small Gds to avoid nonconvergence
-		Gds = 1e-8;
-		ids = .5*beta*(vgs-vt)*(vgs-vt) + (vds-(vgs-vt))*Gds;
+		if (Gds < 1e-8)
+		    Gds = 1e-8;
 		mode = 2;
 	    }
 	    
@@ -438,7 +444,9 @@ class MosfetElm extends CircuitElm {
 	void getFetInfo(String arr[], String n) {
 	    arr[0] = Locale.LS(((pnp == -1) ? "p-" : "n-") + n);
 	    arr[0] += " (Vt=" + getVoltageText(pnp*vt);
-	    arr[0] += ", \u03b2=" + beta + ")";
+	    arr[0] += ", \u03b2=" + beta;
+	    if (lambda > 0) arr[0] += ", \u03bb=" + lambda;
+	    arr[0] += ")";
 	    arr[1] = ((pnp == 1) ? "Ids = " : "Isd = ") + getCurrentText(ids);
 	    arr[2] = "Vgs = " + getVoltageText(volts[0]-volts[pnp == -1 ? 2 : 1]);
 	    arr[3] = ((pnp == 1) ? "Vds = " : "Vsd = ") + getVoltageText(volts[2]-volts[1]);
@@ -466,27 +474,29 @@ class MosfetElm extends CircuitElm {
 			return new EditInfo("Threshold Voltage", pnp*vt, .01, 5);
 		if (n == 1)
 			return new EditInfo(EditInfo.makeLink("mosfet-beta.html", "Beta"), beta, .01, 5);
-		if (n == 2) {
+		if (n == 2)
+			return new EditInfo("Channel-Length Modulation (1/V)", lambda, 0, 0).setDimensionless();
+		if (n == 3) {
 			EditInfo ei = new EditInfo("", 0, -1, -1);
 			ei.checkbox = new Checkbox("Show Bulk", showBulk());
 			return ei;
 		}
-		if (n == 3) {
+		if (n == 4) {
 			EditInfo ei = new EditInfo("", 0, -1, -1);
 			ei.checkbox = new Checkbox("Swap D/S", (flags & FLAG_FLIP) != 0);
 			return ei;
 		}
-		if (n == 4 && !showBulk()) {
+		if (n == 5 && !showBulk()) {
 			EditInfo ei = new EditInfo("", 0, -1, -1);
 			ei.checkbox = new Checkbox("Digital Symbol", drawDigital());
 			return ei;
 		}
-		if (n == 4 && showBulk()) {
+		if (n == 5 && showBulk()) {
 			EditInfo ei = new EditInfo("", 0, -1, -1);
 			ei.checkbox = new Checkbox("Simulate Body Diode", (flags & FLAG_BODY_DIODE) != 0);
 			return ei;
 		}
-		if (n == 5 && doBodyDiode()) {
+		if (n == 6 && doBodyDiode()) {
 			EditInfo ei = new EditInfo("", 0, -1, -1);
 			ei.checkbox = new Checkbox("Body Terminal", (flags & FLAG_BODY_TERMINAL) != 0);
 			return ei;
@@ -498,28 +508,30 @@ class MosfetElm extends CircuitElm {
 		if (n == 0)
 			vt = pnp*ei.value;
 		if (n == 1 && ei.value > 0)
-			beta = lastBeta = ei.value;	
-		if (n == 2) {
+			beta = lastBeta = ei.value;
+		if (n == 2 && ei.value >= 0)
+			lambda = ei.value;
+		if (n == 3) {
 		    globalFlags = (!ei.checkbox.getState()) ? (globalFlags|FLAG_HIDE_BULK) :
 				(globalFlags & ~(FLAG_HIDE_BULK|FLAG_DIGITAL));
 //		    setPoints();
 		    ei.newDialog = true;
 		}
-		if (n == 3) {
+		if (n == 4) {
 			flags = (ei.checkbox.getState()) ? (flags | FLAG_FLIP) :
 				(flags & ~FLAG_FLIP);
 //			setPoints();
 		}
-		if (n == 4 && !showBulk()) {
+		if (n == 5 && !showBulk()) {
 		    globalFlags = (ei.checkbox.getState()) ? (globalFlags|FLAG_DIGITAL) :
 				(globalFlags & ~FLAG_DIGITAL);
 //		    setPoints();
 		}
-		if (n == 4 && showBulk()) {
+		if (n == 5 && showBulk()) {
 		    flags = ei.changeFlag(flags, FLAG_BODY_DIODE);
 		    ei.newDialog = true;
 		}
-		if (n == 5) {
+		if (n == 6) {
 		    flags = ei.changeFlag(flags, FLAG_BODY_TERMINAL);
 		}
 

--- a/src/com/lushprojects/circuitjs1/client/Scope.java
+++ b/src/com/lushprojects/circuitjs1/client/Scope.java
@@ -237,6 +237,7 @@ class Scope {
     Canvas imageCanvas;
     Context2d imageContext;
     int alphaCounter =0;
+    int trailLen = 2; // controls XY trail fade speed (higher = longer persistence)
     // scopeTimeStep to check if sim timestep has changed from previous value when redrawing
     double scopeTimeStep;
     double scale[]; // Max value to scale the display to show - indexed for each value of UNITS - e.g. UNITS_V, UNITS_A etc.
@@ -800,8 +801,8 @@ class Scope {
     	g.clipRect(0, 0, rect.width, rect.height);
     	
     	alphaCounter++;
-    	
-    	if (alphaCounter>2) {
+
+    	if (trailLen < 50 && alphaCounter > trailLen) {
     		// fade out plot
     		alphaCounter=0;
     		imageContext.setGlobalAlpha(0.01);

--- a/src/com/lushprojects/circuitjs1/client/ScopePropertiesDialog.java
+++ b/src/com/lushprojects/circuitjs1/client/ScopePropertiesDialog.java
@@ -58,11 +58,11 @@ CheckBox rmsBox, dutyBox, viBox, xyBox, resistanceBox, ibBox, icBox, ieBox, vbeB
 CheckBox elmInfoBox;
 TextBox labelTextBox, manualScaleTextBox, divisionsTextBox;
 Button applyButton, scaleUpButton, scaleDownButton;
-Scrollbar speedBar,positionBar;
+Scrollbar speedBar, positionBar, trailBar;
 Scope scope;
 Grid grid, vScaleGrid, hScaleGrid;
 int nx, ny;
-Label scopeSpeedLabel, manualScaleLabel,vScaleList, manualScaleId, positionLabel, divisionsLabel;
+Label scopeSpeedLabel, manualScaleLabel,vScaleList, manualScaleId, positionLabel, divisionsLabel, trailLabel;
 expandingLabel vScaleLabel, hScaleLabel;
 Vector <Button> chanButtons = new Vector <Button>();
 int plotSelection = 0;
@@ -424,6 +424,19 @@ labelledGridManager gridLabels;
 		viBox.addValueChangeHandler(this); 
 		addItemToGrid(grid, xyBox = new ScopeCheckBox(Locale.LS("Plot X/Y"), "plotxy"));
 		xyBox.addValueChangeHandler(this);
+		Grid trailGrid = new Grid(1, 3);
+		trailGrid.setWidget(0, 0, new Label(Locale.LS("Trail Persistence")));
+		trailBar = new Scrollbar(Scrollbar.HORIZONTAL, scope.trailLen, 1, 0, 51, new Command() {
+		    public void execute() {
+			scope.trailLen = trailBar.getValue();
+			setTrailLabel();
+		    }
+		});
+		trailGrid.setWidget(0, 1, trailBar);
+		trailLabel = new Label("");
+		trailGrid.setWidget(0, 2, trailLabel);
+		fp.add(trailGrid);
+		setTrailLabel();
 		if (transistor) {
 		    addItemToGrid(grid, vceIcBox = new ScopeCheckBox(Locale.LS("Show Vce vs Ic"), "showvcevsic"));
 		    vceIcBox.addValueChangeHandler(this);
@@ -528,6 +541,13 @@ labelledGridManager gridLabels;
 	
 	void setScopeSpeedLabel() {
 	    scopeSpeedLabel.setText(CircuitElm.getUnitText(scope.calcGridStepX(), "s")+"/div");
+	}
+
+	void setTrailLabel() {
+	    if (scope.trailLen >= 50)
+		trailLabel.setText("max");
+	    else
+		trailLabel.setText("" + scope.trailLen);
 	}
 	
 	void addItemToGrid(Grid g, FocusWidget scb) {


### PR DESCRIPTION
## Summary
- **MOSFET channel-length modulation** (fixes #155): Adds a lambda parameter to MosfetElm/JfetElm for finite output resistance in saturation. In saturation region: Ids = 0.5*beta*(Vgs-Vt)^2*(1+lambda*Vds), Gds = 0.5*beta*(Vgs-Vt)^2*lambda. Default is 0 (ideal square-law, backward compatible). Shown in the info panel when non-zero.
- **Scope XY trail persistence** (fixes #157): Adds a "Trail Persistence" slider (0-50) in the scope properties dialog under XY Plots. Values 0-49 control fade speed (lower = faster fade); 50 = infinite persistence (no fade). Default is 2 (matches previous hardcoded behavior).

## Changes
- MosfetElm.java: Added lambda field, channel-length modulation math in saturation, serialization, edit dialog entry at n=2 (shifted subsequent items)
- JfetElm.java: Extended getEditInfo threshold from n < 2 to n < 3 to expose lambda
- Scope.java: Added trailLen field, changed fade condition to use configurable threshold
- ScopePropertiesDialog.java: Added trail persistence scrollbar and label after XY plot checkboxes

## Test plan
- [ ] Place an n-MOSFET, set lambda > 0 (e.g. 0.02), verify finite output resistance in saturation (Ids increases with Vds)
- [ ] Place a JFET, verify lambda parameter appears in edit dialog
- [ ] Open scope XY plot, adjust Trail Persistence slider and verify fade behavior changes
- [ ] Verify lambda=0 (default) gives identical behavior to before
- [ ] Verify existing circuits load without issues (backward-compatible dump format)
