### PR TITLE
Add optocoupler CTR, SRAM reset restore, voltage-limited current source, macOS paste fix

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -12,7 +12,38 @@ const url = require('url')
 // be closed automatically when the JavaScript object is garbage collected.
 var windows = [];
 
-Menu.setApplicationMenu(false);
+// Build a minimal application menu so that standard keyboard shortcuts
+// (Cmd+C, Cmd+V, Cmd+X, Cmd+A) work in text fields on macOS.
+// Setting the menu to false disables these shortcuts entirely.
+var template = [
+  {
+    label: 'Edit',
+    submenu: [
+      { role: 'undo' },
+      { role: 'redo' },
+      { type: 'separator' },
+      { role: 'cut' },
+      { role: 'copy' },
+      { role: 'paste' },
+      { role: 'selectAll' }
+    ]
+  }
+];
+if (process.platform === 'darwin') {
+  template.unshift({
+    label: app.getName(),
+    submenu: [
+      { role: 'about' },
+      { type: 'separator' },
+      { role: 'hide' },
+      { role: 'hideOthers' },
+      { role: 'unhide' },
+      { type: 'separator' },
+      { role: 'quit' }
+    ]
+  });
+}
+Menu.setApplicationMenu(Menu.buildFromTemplate(template));
 
 // save arguments
 global.sharedObject = {prop1: process.argv};

--- a/src/com/lushprojects/circuitjs1/client/CurrentElm.java
+++ b/src/com/lushprojects/circuitjs1/client/CurrentElm.java
@@ -20,7 +20,10 @@
 package com.lushprojects.circuitjs1.client;
 
     class CurrentElm extends CircuitElm {
+	static final int FLAG_VOLTAGE_LIMIT = 1;
 	double currentValue;
+	double maxVoltage = 1e8;
+	double lastVoltDiff;
 	boolean broken;
 	public CurrentElm(int xx, int yy) {
 	    super(xx, yy);
@@ -31,12 +34,19 @@ package com.lushprojects.circuitjs1.client;
 	    super(xa, ya, xb, yb, f);
 	    try {
 		currentValue = new Double(st.nextToken()).doubleValue();
-	    } catch (Exception e) {
+		maxVoltage = new Double(st.nextToken()).doubleValue();
+	    } catch (Exception e) {}
+	    if (currentValue == 0)
 		currentValue = .01;
-	    }
+	}
+	boolean isVoltageLimited() { return (flags & FLAG_VOLTAGE_LIMIT) != 0; }
+	boolean nonLinear() { return isVoltageLimited(); }
+	void reset() {
+	    super.reset();
+	    lastVoltDiff = 0;
 	}
 	String dump() {
-	    return super.dump() + " " + currentValue;
+	    return super.dump() + " " + currentValue + " " + maxVoltage;
 	}
 	int getDumpType() { return 'i'; }
 	
@@ -82,25 +92,67 @@ package com.lushprojects.circuitjs1.client;
 		// no current path; stamping a current source would cause a matrix error.
 		sim.stampResistor(nodes[0], nodes[1], 1e8);
 		current = 0;
+	    } else if (isVoltageLimited()) {
+		// voltage-limited mode: stamp as nonlinear, doStep() will handle it
+		sim.stampNonLinear(nodes[0]);
+		sim.stampNonLinear(nodes[1]);
 	    } else {
 		// ok to stamp a current source
 		sim.stampCurrentSource(nodes[0], nodes[1], currentValue);
 		current = currentValue;
 	    }
 	}
+
+	void doStep() {
+	    if (!isVoltageLimited() || broken)
+		return;
+	    double vd = volts[1] - volts[0];
+	    if (Math.abs(lastVoltDiff - vd) > .01)
+		sim.converged = false;
+	    lastVoltDiff = vd;
+
+	    double absVd = Math.abs(vd);
+	    if (absVd <= maxVoltage) {
+		// within compliance: act as ideal current source
+		sim.stampResistor(nodes[0], nodes[1], 1e8);
+		sim.stampCurrentSource(nodes[0], nodes[1], currentValue);
+		current = currentValue;
+	    } else {
+		// beyond compliance: act as high-impedance (open circuit)
+		sim.stampResistor(nodes[0], nodes[1], 1e8);
+		current = vd / 1e8;
+	    }
+	}
 	
 	public EditInfo getEditInfo(int n) {
 	    if (n == 0)
 		return new EditInfo("Current (A)", currentValue, 0, .1);
+	    if (n == 1) {
+		EditInfo ei = new EditInfo("", 0, -1, -1);
+		ei.checkbox = new Checkbox("Voltage Limited",
+		    isVoltageLimited());
+		return ei;
+	    }
+	    if (n == 2 && isVoltageLimited())
+		return new EditInfo("Max Voltage (V)", maxVoltage, 0, 0);
 	    return null;
 	}
 	public void setEditValue(int n, EditInfo ei) {
-	    currentValue = ei.value;
+	    if (n == 0)
+		currentValue = ei.value;
+	    if (n == 1) {
+		flags = ei.changeFlag(flags, FLAG_VOLTAGE_LIMIT);
+		ei.newDialog = true;
+	    }
+	    if (n == 2 && ei.value > 0)
+		maxVoltage = ei.value;
 	}
 	void getInfo(String arr[]) {
 	    arr[0] = "current source";
 	    int i = getBasicInfo(arr);
             arr[i++] = "P = " + getUnitText(getPower(), "W");
+	    if (isVoltageLimited())
+		arr[i++] = "Vmax = " + getVoltageText(maxVoltage);
 	}
 	double getVoltageDiff() {
 	    return volts[1] - volts[0];

--- a/src/com/lushprojects/circuitjs1/client/OptocouplerElm.java
+++ b/src/com/lushprojects/circuitjs1/client/OptocouplerElm.java
@@ -4,6 +4,7 @@ public class OptocouplerElm extends CompositeElm {
     int csize, cspc, cspc2;
     int rectPointsX[], rectPointsY[];
     double curCounts[];
+    double ctr = 1.0; // current transfer ratio (1.0 = 100%)
 
     private static String modelString = "DiodeElm 6 1\rCCCSElm 1 2 3 4\rNTransistorElm 3 4 5";
     private static int[] modelExternalNodes = { 6, 2, 4, 5 };
@@ -21,11 +22,16 @@ public class OptocouplerElm extends CompositeElm {
 	// pass st=null since we don't need to undump any of the sub-elements
 	super(xa, ya, xb, yb, f, null, modelString, modelExternalNodes);
 	noDiagonal = true;
+	try {
+	    ctr = new Double(st.nextToken()).doubleValue();
+	} catch (Exception e) {
+	    ctr = 1.0;
+	}
 	initOptocoupler();
     }
 
     public String dump() {
-	return dumpWithMask(0);
+	return dumpWithMask(0) + " " + ctr;
     }
     
     private void initOptocoupler() {
@@ -36,7 +42,8 @@ public class OptocouplerElm extends CompositeElm {
 	CCCSElm cccs = (CCCSElm) compElmList.get(1);
 	
 	// from http://www.cel.com/pdf/appnotes/an3017.pdf
-	cccs.setExpr("max(0,min(.0001, select(i-.003, (-80000000000*(i)^5+800000000*(i)^4-3000000*(i)^3+5177.2*(i)^2+.2453*(i)-.00005)*1.04/700, (9000000*(i)^5-998113*(i)^4+42174*(i)^3-861.32*(i)^2+9.0836*(i)-.0078)*.945/700)))");
+	// the base expression models a ~100% CTR device; we scale by ctr
+	cccs.setExpr(ctr + "*max(0,min(.0001, select(i-.003, (-80000000000*(i)^5+800000000*(i)^4-3000000*(i)^3+5177.2*(i)^2+.2453*(i)-.00005)*1.04/700, (9000000*(i)^5-998113*(i)^4+42174*(i)^3-861.32*(i)^2+9.0836*(i)-.0078)*.945/700)))");
 	
 	transistor = (TransistorElm) compElmList.get(2);
 	transistor.setBeta(700);
@@ -177,11 +184,21 @@ public class OptocouplerElm extends CompositeElm {
 
     void getInfo(String arr[]) {
 	arr[0] = "optocoupler";
-	arr[1] = "Iin = " + getCurrentText(getCurrentIntoNode(0));
-	arr[2] = "Iout = " + getCurrentText(getCurrentIntoNode(2));
+	arr[1] = "CTR = " + (int)(ctr*100) + "%";
+	arr[2] = "Iin = " + getCurrentText(getCurrentIntoNode(0));
+	arr[3] = "Iout = " + getCurrentText(getCurrentIntoNode(2));
     }
 
     public EditInfo getEditInfo(int n) {
-        return null;
+	if (n == 0)
+	    return new EditInfo("CTR (%)", ctr * 100, 0, 0).setDimensionless();
+	return null;
+    }
+
+    public void setEditValue(int n, EditInfo ei) {
+	if (n == 0 && ei.value > 0) {
+	    ctr = ei.value / 100;
+	    initOptocoupler();
+	}
     }
 }

--- a/src/com/lushprojects/circuitjs1/client/SRAMElm.java
+++ b/src/com/lushprojects/circuitjs1/client/SRAMElm.java
@@ -28,6 +28,8 @@ import com.google.gwt.user.client.ui.TextArea;
 	int addressNodes, dataNodes, internalNodes;
 	int addressBits, dataBits;
 	HashMap<Integer, Integer> map;
+	HashMap<Integer, Integer> initialMap; // saved initial contents for restore on reset
+	static final int FLAG_RELOAD_ON_RESET = 2;
 	static String contentsOverride = null;
 
 	public SRAMElm(int xx, int yy) {
@@ -61,6 +63,8 @@ import com.google.gwt.user.client.ui.TextArea;
 		    }
 		}
 	    } catch (Exception e) {}
+	    if ((flags & FLAG_RELOAD_ON_RESET) != 0)
+		initialMap = new HashMap<Integer, Integer>(map);
 	}
 
 	String dump() {
@@ -84,6 +88,12 @@ import com.google.gwt.user.client.ui.TextArea;
 	    }
 	    s += " -2";
 	    return s;
+	}
+
+	void reset() {
+	    super.reset();
+	    if ((flags & FLAG_RELOAD_ON_RESET) != 0 && initialMap != null)
+		map = new HashMap<Integer, Integer>(initialMap);
 	}
 
 	boolean nonLinear() { return true; }
@@ -158,6 +168,12 @@ import com.google.gwt.user.client.ui.TextArea;
             	ei.newDialog = true;
             	return ei;
             }
+	    if (n == 4 || (n == 3 && !SRAMLoadFile.isSupported())) {
+		EditInfo ei = new EditInfo("", 0, -1, -1);
+		ei.checkbox = new Checkbox("Restore Contents on Reset",
+		    (flags & FLAG_RELOAD_ON_RESET) != 0);
+		return ei;
+	    }
 	    return super.getChipEditInfo(n);
 	}
 	
@@ -198,6 +214,15 @@ import com.google.gwt.user.client.ui.TextArea;
 			}
 		    } catch (Exception e) {}
 		}
+		if ((flags & FLAG_RELOAD_ON_RESET) != 0)
+		    initialMap = new HashMap<Integer, Integer>(map);
+	    }
+	    if (n == 4 || (n == 3 && !SRAMLoadFile.isSupported())) {
+		flags = ei.changeFlag(flags, FLAG_RELOAD_ON_RESET);
+		if ((flags & FLAG_RELOAD_ON_RESET) != 0)
+		    initialMap = new HashMap<Integer, Integer>(map);
+		else
+		    initialMap = null;
 	    }
 	}
 	int getVoltageSourceCount() { return dataBits; }


### PR DESCRIPTION
## Summary
- **Configurable optocoupler CTR** (fixes #150): Adds a Current Transfer Ratio parameter (default 100%) to the optocoupler edit dialog. The CTR scales the CCCS transfer expression, letting users model optocouplers with different transfer characteristics.
- **SRAM restore on reset** (fixes #184): Adds a "Restore Contents on Reset" checkbox. When enabled, the SRAM stores a snapshot of its contents when loaded/edited, and restores that snapshot on simulation reset instead of keeping runtime modifications.
- **Voltage-limited current source** (fixes #149): Adds an optional compliance voltage to the current source. When "Voltage Limited" is checked, a "Max Voltage" field appears. The source operates normally within compliance but becomes open-circuit when the voltage exceeds the limit.
- **macOS Electron paste fix** (fixes #138): Replaces `Menu.setApplicationMenu(false)` with a proper Edit menu containing Cut/Copy/Paste/SelectAll roles. On macOS, disabling the app menu also disables standard keyboard shortcuts (Cmd+C/V/X/A) in text input fields.

## Changes
- `OptocouplerElm.java`: Added `ctr` field, scaled CCCS expression, edit dialog, serialization
- `SRAMElm.java`: Added `initialMap`, `FLAG_RELOAD_ON_RESET`, `reset()` override, checkbox in edit dialog
- `CurrentElm.java`: Added `FLAG_VOLTAGE_LIMIT`, `maxVoltage`, `doStep()` with compliance clamping, nonlinear stamping, edit dialog
- `app/main.js`: Replaced disabled menu with Edit menu + macOS app menu with Quit

## Test plan
- [ ] Place optocoupler, change CTR to 200%, verify output current roughly doubles
- [ ] Place SRAM, load contents, enable "Restore Contents on Reset", run sim (write to SRAM), hit Reset, verify original contents restored
- [ ] Place current source, enable "Voltage Limited", set Max Voltage to 10V, connect to high-value resistor, verify current stops when voltage hits limit
- [ ] On macOS Electron app, verify Cmd+V pastes text into text fields (e.g., label editor)
- [ ] Verify existing circuits load without issues (backward-compatible serialization)
