### PR TITLE
Fix image export clipping, subcircuit creation, Mac Ctrl+click, OpAmpReal connectivity

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/CirSim.java
+++ b/src/com/lushprojects/circuitjs1/client/CirSim.java
@@ -1440,6 +1440,17 @@ MouseOutHandler, MouseWheelHandler {
     		}
     		miny = min(ce.y, min(ce.y2, miny));
     		maxy = max(ce.y, max(ce.y2, maxy));
+    		// use boundingBox for elements like chips/subcircuits whose
+    		// visual extent exceeds their x/y coordinates
+    		Rectangle bb = ce.getBoundingBox();
+    		if (bb != null) {
+    		    if (!ce.isCenteredText()) {
+    			minx = min(bb.x, minx);
+    			maxx = max(bb.x + bb.width, maxx);
+    		    }
+    		    miny = min(bb.y, miny);
+    		    maxy = max(bb.y + bb.height, maxy);
+    		}
     	}
     	if (minx > maxx)
     	    return null;
@@ -4690,6 +4701,10 @@ MouseOutHandler, MouseWheelHandler {
 
     public void onContextMenu(ContextMenuEvent e) {
     	e.preventDefault();
+    	// on Mac, Ctrl+click sends a context menu event; suppress it so
+    	// Ctrl+click can be used for selection instead
+    	if (isMac && e.getNativeEvent().getCtrlKey())
+    	    return;
     	if (!dialogIsShowing()) {
         	menuClientX = e.getNativeEvent().getClientX();
         	menuClientY = e.getNativeEvent().getClientY();
@@ -6601,14 +6616,13 @@ MouseOutHandler, MouseWheelHandler {
 		}
 	    }
 	
-	    boolean first = true;
 	    for (i = 0; i != unconnectedNodes.size(); i++) {
 		int q = unconnectedNodes.get(i);
 		if (!extnodes[q] && used[q]) {
-		    if (nodesWithGroundConnectionCount == 0 && first) {
-			first = false;
+		    // when circuit has no ground, unconnected node detection is
+		    // unreliable so skip the check entirely
+		    if (nodesWithGroundConnectionCount == 0)
 			continue;
-		    }
 		    Window.alert("Some nodes are unconnected!");
 		    return null;
 		}

--- a/src/com/lushprojects/circuitjs1/client/OpAmpRealElm.java
+++ b/src/com/lushprojects/circuitjs1/client/OpAmpRealElm.java
@@ -155,10 +155,6 @@ public class OpAmpRealElm extends CompositeElm {
 	return super.dumpWithMask(0) + " " + slewRate + " " + voltdiff + " " + currentLimit + " " + modelType;
     }
     
-    public boolean getConnection(int n1, int n2) {
-	return true;
-    }
-
     void draw(Graphics g) {
         setBbox(point1, point2, opheight*2);
         setVoltageColor(g, volts[0]);


### PR DESCRIPTION
## Summary

Four targeted bug fixes across 2 files (26 lines changed):

- **Fix #219**: `getCircuitBounds()` now uses `boundingBox` in addition to `x/x2/y/y2`, so chips and subcircuits are no longer clipped when exporting as image/SVG
- **Fix #191**: Skip unconnected node check entirely when circuit has no ground connection, allowing logic-only circuits (e.g. multiple connected gates) to be saved as subcircuits without false "Some nodes are unconnected!" errors
- **Fix #51**: Suppress context menu on Mac Ctrl+click so it can be used for multi-selection instead of triggering right-click popup
- **Fix #55**: Remove `getConnection()` override from `OpAmpRealElm` that always returned `true`, allowing `CompositeElm`'s proper connectivity analysis to work and preventing false current paths through the op-amp model

## Test plan

- [ ] Create a circuit with chips/subcircuits, export as image — verify nothing is clipped
- [ ] Create a logic-only circuit (no ground), select all, File > Save As Subcircuit — verify it succeeds
- [ ] On Mac, Ctrl+click on canvas — verify no context menu appears
- [ ] Place an OpAmpReal with shorted supply pins — verify no "free energy" current flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)
