### PR TITLE
Add configurable simulation temperature for diodes and transistors

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/CirSim.java
+++ b/src/com/lushprojects/circuitjs1/client/CirSim.java
@@ -212,6 +212,17 @@ MouseOutHandler, MouseWheelHandler {
 
     double wheelSensitivity = 1;
 
+    // simulation temperature in Kelvin, default 27 C (300.15K) like SPICE
+    static double temperature = 300.15;
+    // electron thermal voltage = k*T/q, recalculated when temperature changes
+    static double vt = 0.025865;
+
+    static void setTemperature(double tempKelvin) {
+	temperature = tempKelvin;
+	vt = 1.380649e-23 * tempKelvin / 1.602176634e-19;
+	DiodeModel.updateAllModels();
+    }
+
     // accumulated time since we incremented timeStepCount
     double timeStepAccum;
 

--- a/src/com/lushprojects/circuitjs1/client/Diode.java
+++ b/src/com/lushprojects/circuitjs1/client/Diode.java
@@ -33,7 +33,8 @@ class Diode {
 	zvoltage = model.breakdownVoltage;
 	vscale = model.vscale;
 	vdcoef = model.vdcoef;
-	
+	vzcoef = 1 / CirSim.vt;
+
 //	sim.console("setup " + leakage + " " + zvoltage + " " + model.emissionCoefficient + " " +  vdcoef);
 
 	// critical voltage for limiting; current is vscale/sqrt(2) at
@@ -41,7 +42,7 @@ class Diode {
 	vcrit = vscale * Math.log(vscale/(Math.sqrt(2)*leakage));
 	// translated, *positive* critical voltage for limiting in Zener breakdown region;
 	// limitstep() uses this with translated voltages in an analogous fashion to vcrit.
-	vzcrit = vt * Math.log(vt/(Math.sqrt(2)*leakage));
+	vzcrit = CirSim.vt * Math.log(CirSim.vt/(Math.sqrt(2)*leakage));
 	if (zvoltage == 0)
 	    zoffset = 0;
 	else {
@@ -59,8 +60,6 @@ class Diode {
 	lastvoltdiff = 0;
     }
 	
-    // Electron thermal voltage at SPICE's default temperature of 27 C (300.15 K):
-    static final double vt = 0.025865;
     // The diode's "scale voltage", the voltage increase which will raise current by a factor of e.
     double vscale;
     // The multiplicative equivalent of dividing by vscale (for speed).
@@ -69,7 +68,7 @@ class Diode {
     // Shockley curve, but flipped and translated. This curve removes the moderating influence
     // of emcoef, replacing vscale and vdcoef with vt and vzcoef.
     // vzcoef is the multiplicative equivalent of dividing by vt (for speed).
-    static final double vzcoef = 1 / vt;
+    double vzcoef;
     // User-specified diode parameters for forward voltage drop and Zener voltage.
     double fwdrop, zvoltage;
     // The diode current's scale factor, calculated from the user-specified forward voltage drop.
@@ -111,17 +110,17 @@ class Diode {
 	    vnew = -vnew - zoffset;
 	    vold = -vold - zoffset;
 	    
-	    if (vnew > vzcrit && Math.abs(vnew - vold) > (vt + vt)) {
+	    if (vnew > vzcrit && Math.abs(vnew - vold) > (CirSim.vt + CirSim.vt)) {
 		if(vold > 0) {
-		    arg = 1 + (vnew - vold) / vt;
+		    arg = 1 + (vnew - vold) / CirSim.vt;
 		    if(arg > 0) {
-			vnew = vold + vt * Math.log(arg);
+			vnew = vold + CirSim.vt * Math.log(arg);
 			//System.out.println(oo + " " + vnew);
 		    } else {
 			vnew = vzcrit;
 		    }
 		} else {
-		    vnew = vt *Math.log(vnew/vt);
+		    vnew = CirSim.vt *Math.log(vnew/CirSim.vt);
 		}
 		sim.converged = false;
 	    }

--- a/src/com/lushprojects/circuitjs1/client/DiodeModel.java
+++ b/src/com/lushprojects/circuitjs1/client/DiodeModel.java
@@ -26,8 +26,6 @@ public class DiodeModel implements Editable, Comparable<DiodeModel> {
     boolean internal;
     static final int FLAGS_SIMPLE = 1; 
     
-    // Electron thermal voltage at SPICE's default temperature of 27 C (300.15 K):
-    static final double vt = 0.025865;
     // The diode's "scale voltage", the voltage increase which will raise current by a factor of e.
     double vscale;
     // The multiplicative equivalent of dividing by vscale (for speed).
@@ -137,7 +135,7 @@ public class DiodeModel implements Editable, Comparable<DiodeModel> {
 	}
 
 	// create a new one, converting to new parameter values
-	final double vscale = emcoef * vt;
+	final double vscale = emcoef * CirSim.vt;
 	final double vdcoef = 1 / vscale;
 	double leakage = 1 / (Math.exp(fwdrop * vdcoef) - 1);
 	String name = "fwdrop=" + fwdrop;
@@ -163,6 +161,16 @@ public class DiodeModel implements Editable, Comparable<DiodeModel> {
         StringTokenizer st = new StringTokenizer(s);
         DiodeModel dm = undumpModel(st);
         dm.builtIn = dm.internal = true;
+    }
+
+    static void updateAllModels() {
+	if (modelMap == null)
+	    return;
+	Iterator it = modelMap.entrySet().iterator();
+	while (it.hasNext()) {
+	    Map.Entry<String,DiodeModel> pair = (Map.Entry)it.next();
+	    pair.getValue().updateModel();
+	}
     }
 
     static void clearDumpedFlags() {
@@ -292,7 +300,7 @@ public class DiodeModel implements Editable, Comparable<DiodeModel> {
     // set emission coefficient for simple mode if we have enough data  
     void setEmissionCoefficient() {
 	if (forwardCurrent > 0 && forwardVoltage > 0)
-	    emissionCoefficient = (forwardVoltage/Math.log(forwardCurrent/saturationCurrent+1)) / vt;
+	    emissionCoefficient = (forwardVoltage/Math.log(forwardCurrent/saturationCurrent+1)) / CirSim.vt;
 
 	seriesResistance = 0;
     }
@@ -300,13 +308,13 @@ public class DiodeModel implements Editable, Comparable<DiodeModel> {
     public void setForwardVoltage() {
 	if (forwardCurrent == 0)
 	    forwardCurrent = 1;
-	forwardVoltage = emissionCoefficient*vt * Math.log(forwardCurrent/saturationCurrent+1);
+	forwardVoltage = emissionCoefficient*CirSim.vt * Math.log(forwardCurrent/saturationCurrent+1);
     }
     
     void updateModel() {
-	vscale = emissionCoefficient * vt;
+	vscale = emissionCoefficient * CirSim.vt;
 	vdcoef = 1/vscale;
-	fwdrop = Math.log(1/saturationCurrent + 1) * emissionCoefficient * vt;
+	fwdrop = Math.log(1/saturationCurrent + 1) * emissionCoefficient * CirSim.vt;
     }
     
     String dump() {

--- a/src/com/lushprojects/circuitjs1/client/EditOptions.java
+++ b/src/com/lushprojects/circuitjs1/client/EditOptions.java
@@ -84,7 +84,9 @@ class EditOptions implements Editable {
 		    ei.checkbox = new Checkbox("Auto-Adjust Timestep", sim.adjustTimeStep);
 		    return ei;
 		}
-		if (n == 14 && sim.adjustTimeStep)
+		if (n == 14)
+		    return new EditInfo("Simulation Temperature (\u00b0C)", CirSim.temperature - 273.15, 0, 0);
+		if (n == 15 && sim.adjustTimeStep)
 		    return new EditInfo("Minimum time step size (s)", sim.minTimeStep, 0, 0);
 
 		return null;
@@ -167,7 +169,14 @@ class EditOptions implements Editable {
 		    sim.adjustTimeStep = ei.checkbox.getState();
 		    ei.newDialog = true;
 		}
-		if (n == 14 && ei.value > 0)
+		if (n == 14) {
+		    double tempK = ei.value + 273.15;
+		    if (tempK > 0) {
+			CirSim.setTemperature(tempK);
+			sim.updateModels();
+		    }
+		}
+		if (n == 15 && ei.value > 0)
 		    sim.minTimeStep = ei.value;
 	}
 	

--- a/src/com/lushprojects/circuitjs1/client/TransistorElm.java
+++ b/src/com/lushprojects/circuitjs1/client/TransistorElm.java
@@ -70,7 +70,7 @@ class TransistorElm extends CircuitElm {
 	void setup() {
 	    model = TransistorModel.getModelWithNameOrCopy(modelName, model);
 	    modelName = model.name;   // in case we couldn't find that model    
-	    vcrit = vt * Math.log(vt/(Math.sqrt(2)*model.satCur));
+	    vcrit = CirSim.vt * Math.log(CirSim.vt/(Math.sqrt(2)*model.satCur));
 	    noDiagonal = true;
 	}
 	boolean nonLinear() { return true; }
@@ -199,24 +199,22 @@ class TransistorElm extends CircuitElm {
 	}
 	
 	static final double leakage = 1e-13; // 1e-6;
-	// Electron thermal voltage at SPICE's default temperature of 27 C (300.15 K):
-	static final double vt = 0.025865;
 	double vcrit;
 	double lastvbc, lastvbe;
 	double limitStep(double vnew, double vold) {
 	    double arg;
 	    double oo = vnew;
 	    
-	    if (vnew > vcrit && Math.abs(vnew - vold) > (vt + vt)) {
+	    if (vnew > vcrit && Math.abs(vnew - vold) > (CirSim.vt + CirSim.vt)) {
 		if(vold > 0) {
-		    arg = 1 + (vnew - vold) / vt;
+		    arg = 1 + (vnew - vold) / CirSim.vt;
 		    if(arg > 0) {
-			vnew = vold + vt * Math.log(arg);
+			vnew = vold + CirSim.vt * Math.log(arg);
 		    } else {
 			vnew = vcrit;
 		    }
 		} else {
-		    vnew = vt *Math.log(vnew/vt);
+		    vnew = CirSim.vt *Math.log(vnew/CirSim.vt);
 		}
 		sim.converged = false;
 		//System.out.println(vnew + " " + oo + " " + vold);
@@ -260,16 +258,16 @@ class TransistorElm extends CircuitElm {
             double csat=model.satCur;
             double oik=model.invRollOffF;
             double c2=model.BEleakCur;
-            double vte=model.leakBEemissionCoeff*vt;
+            double vte=model.leakBEemissionCoeff*CirSim.vt;
             double oikr=model.invRollOffR;
             double c4=model.BCleakCur;
-            double vtc=model.leakBCemissionCoeff*vt;
+            double vtc=model.leakBCemissionCoeff*CirSim.vt;
             
 //          double rbpr=model.minBaseResist;
 //          double rbpi=model.baseResist-rbpr;
 //          double xjrb=model.baseCurrentHalfResist;
             
-            double vtn=vt*model.emissionCoeffF;
+            double vtn=CirSim.vt*model.emissionCoeffF;
             double evbe, cbe, gbe, cben, gben, evben, evbc, cbc, gbc, cbcn, gbcn, evbcn;
             double qb, dqbdve, dqbdvc, q2, sqarg, arg;
             if(vbe > -5*vtn){
@@ -290,7 +288,7 @@ class TransistorElm extends CircuitElm {
                 gben = -c2/vbe;
                 cben=gben*vbe;
             }
-            vtn=vt*model.emissionCoeffR;
+            vtn=CirSim.vt*model.emissionCoeffR;
             if(vbc > -5*vtn) {
                 evbc=Math.exp(vbc/vtn);
                 cbc=csat*(evbc-1)+gmin*vbc;


### PR DESCRIPTION
## Summary

Adds a configurable simulation temperature parameter, replacing the hardcoded 27°C (300.15K) thermal voltage used by diodes and transistors.

- **Fix #147**: The thermal voltage `vt = k*T/q` (Boltzmann constant * temperature / elementary charge) was hardcoded to 0.025865V (27°C) in `Diode.java`, `DiodeModel.java`, and `TransistorElm.java`. This PR makes it dynamic:
  - `CirSim.temperature` (Kelvin) and `CirSim.vt` (thermal voltage) as central static fields
  - `CirSim.setTemperature()` recalculates vt and refreshes all diode models
  - All three files now reference `CirSim.vt` instead of local hardcoded constants
  - `Diode.vzcoef` (Zener coefficient) becomes a dynamic instance variable
  - New `DiodeModel.updateAllModels()` propagates temperature changes to all models
  - Temperature setting in **Other Options** dialog (°C input)

Changes across 5 files (54 insertions, 29 deletions). Default behavior unchanged (27°C).

## Test plan

- [ ] Open Other Options, verify "Simulation Temperature (°C)" field shows 27
- [ ] Place a diode, check I-V curve at 27°C (should match current behavior exactly)
- [ ] Change temperature to 85°C, verify diode forward voltage decreases (~2mV/°C)
- [ ] Change temperature to -40°C, verify diode forward voltage increases
- [ ] Place a BJT, verify temperature affects Vbe (~2mV/°C)
- [ ] Reset temperature to 27°C, verify original behavior restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)
