### PR TITLE
Add optional pulldown resistors to relay contacts

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/RelayElm.java
+++ b/src/com/lushprojects/circuitjs1/client/RelayElm.java
@@ -38,7 +38,7 @@ class RelayElm extends CircuitElm {
 	
     double inductance;
     Inductor ind;
-    double r_on, r_off, onCurrent, offCurrent;
+    double r_on, r_off, onCurrent, offCurrent, pulldownResistance;
     Point coilPosts[], coilLeads[], swposts[][], swpoles[][], ptSwitch[];
     Point lines[];
     Point outline[] = newPointArray(4);
@@ -97,7 +97,8 @@ class RelayElm extends CircuitElm {
 	    offCurrent = new Double(st.nextToken()).doubleValue();
 	    switchingTime = Double.parseDouble(st.nextToken());
 	    d_position = i_position = Integer.parseInt(st.nextToken());
-	} catch (Exception e) {}	
+	    pulldownResistance = Double.parseDouble(st.nextToken());
+	} catch (Exception e) {}
 	if (i_position == 1)
 	    onState = true;
 	// intermediate state?
@@ -125,7 +126,7 @@ class RelayElm extends CircuitElm {
     String dump() {
 	return super.dump() + " " + poleCount + " " +
 	    inductance + " " + coilCurrent + " " +
-	    r_on + " " + r_off + " " + onCurrent + " " + coilR + " " + offCurrent + " " + switchingTime + " " + i_position;
+	    r_on + " " + r_off + " " + onCurrent + " " + coilR + " " + offCurrent + " " + switchingTime + " " + i_position + " " + pulldownResistance;
     }
     
     void draw(Graphics g) {
@@ -304,6 +305,14 @@ class RelayElm extends CircuitElm {
 	int i;
 	for (i = 0; i != poleCount*3; i++)
 	    sim.stampNonLinear(nodes[nSwitch0+i]);
+
+	// stamp pulldown resistors from NC and NO contacts to ground
+	if (pulldownResistance > 0) {
+	    for (i = 0; i < poleCount; i++) {
+		sim.stampResistor(nodes[nSwitch1+i*3], 0, pulldownResistance);
+		sim.stampResistor(nodes[nSwitch2+i*3], 0, pulldownResistance);
+	    }
+	}
     }
     
     void startIteration() {
@@ -456,6 +465,8 @@ class RelayElm extends CircuitElm {
 	// show switching time only for new model, since it is meaningless for old one
 	if (n == 9 && switchingTime > 0)
 	    return new EditInfo("Switching Time (s)", switchingTime, 0, 0);
+	if (n == 10)
+	    return new EditInfo("Pulldown Resistance (ohms)", pulldownResistance, 0, 0);
 	return null;
     }
     
@@ -496,6 +507,8 @@ class RelayElm extends CircuitElm {
 	    flags = ei.changeFlag(flags, FLAG_SHOW_BOX);
 	if (n == 9 && ei.value > 0)
 	    switchingTime = ei.value;
+	if (n == 10 && ei.value >= 0)
+	    pulldownResistance = ei.value;
     }
     
     boolean getConnection(int n1, int n2) {


### PR DESCRIPTION
## Summary

- Adds an optional **Pulldown Resistance** parameter to relay elements that stamps resistors from each NC and NO contact terminal to ground
- Prevents floating node voltage issues when relay contacts are not connected to a load
- Defaults to 0 (disabled) for full backward compatibility — existing circuits are unaffected
- Accessible via the relay edit dialog and serialized in the dump string

Addresses #101 and #70.

## Test plan

- [ ] Open a relay circuit, verify default behavior unchanged (pulldown = 0)
- [ ] Set pulldown resistance to e.g. 1M ohm, verify floating contacts show ~0V instead of erratic voltages
- [ ] Save and reload circuit, verify pulldown resistance persists
- [ ] Test with multi-pole relays — all poles get pulldown resistors

🤖 Generated with [Claude Code](https://claude.com/claude-code)