### PR TITLE
Add oscilloscope trigger mode for stable waveform display

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/Scope.java
+++ b/src/com/lushprojects/circuitjs1/client/Scope.java
@@ -194,7 +194,22 @@ class Scope {
     final int FLAG_PERPLOT_MAN_SCALE = 1<<19; // new-new style dump with manual included in each plot
     final int FLAG_MAN_SCALE = 16;
     final int FLAG_DIVISIONS = 1<<21; // dump manDivisions
+    final int FLAG_TRIGGER = 1<<22; // trigger mode settings present
     // other flags go here too, see getFlags()
+
+    // Trigger mode constants
+    static final int TRIGGER_FREERUN = 0;
+    static final int TRIGGER_NORMAL = 1;
+    static final int TRIGGER_AUTO = 2;
+
+    // Trigger edge constants
+    static final int TRIGGER_EDGE_RISING = 0;
+    static final int TRIGGER_EDGE_FALLING = 1;
+
+    // Trigger state machine states
+    static final int TRIG_STATE_ARMED = 0;
+    static final int TRIG_STATE_TRIGGERED = 1;
+    static final int TRIG_STATE_AUTO_RUN = 2;
     
     static final int VAL_POWER = 7;
     static final int VAL_POWER_OLD = 1;
@@ -252,7 +267,23 @@ class Scope {
     static int lastManDivisions;
     boolean drawGridLines;
     boolean somethingSelected;
-    
+
+    // Trigger configuration
+    int triggerMode = TRIGGER_FREERUN;
+    int triggerEdge = TRIGGER_EDGE_RISING;
+    double triggerLevel = 0;
+
+    // Trigger state machine
+    int triggerState = TRIG_STATE_ARMED;
+    int triggerPtr = 0;
+    double prevTriggerValue = 0;
+    int triggerHoldoff = 0;
+    int triggerAutoTimeout = 0;
+    boolean triggerWaiting = false;
+    double triggerTime = 0;
+    boolean hasTriggerFired = false;
+    int lastTriggerCheckPtr = -1;
+
     static double cursorTime;
     static int cursorUnits;
     static Scope cursorScope;
@@ -312,6 +343,9 @@ class Scope {
     	scopePointCount = 1;
     	while (scopePointCount <= rect.width)
     		scopePointCount *= 2;
+    	// Double buffer for trigger mode to prevent overwriting displayed data
+    	if (triggerMode != TRIGGER_FREERUN)
+    	    scopePointCount *= 2;
     	if (plots == null)
     	    plots = new Vector<ScopePlot>();
     	showNegative = false;
@@ -321,6 +355,13 @@ class Scope {
 	calcVisiblePlots();
     	scopeTimeStep = sim.maxTimeStep;
     	allocImage();
+    	// Reset trigger state
+    	triggerState = TRIG_STATE_ARMED;
+    	triggerHoldoff = 0;
+    	triggerWaiting = false;
+    	hasTriggerFired = false;
+    	lastTriggerCheckPtr = -1;
+    	triggerAutoTimeout = 2 * scopePointCount;
     }
     
     void setManualScaleValue(int plotId, double d) {
@@ -359,7 +400,140 @@ class Scope {
     }
 
     boolean active() { return plots.size() > 0 && plots.get(0).elm != null; }
-    
+
+    // Returns true if the display is anchored to a trigger point (not free-running)
+    boolean isTriggered() {
+	return triggerMode != TRIGGER_FREERUN && hasTriggerFired && triggerState != TRIG_STATE_AUTO_RUN;
+    }
+
+    // Returns the start index for display, accounting for trigger mode.
+    // In free-run or auto-run mode, delegates to the plot's live start index.
+    // In triggered mode, anchors the display to the trigger point (at center).
+    int displayStartIndex(ScopePlot plot, int w) {
+	if (triggerMode == TRIGGER_FREERUN || !hasTriggerFired || triggerState == TRIG_STATE_AUTO_RUN)
+	    return plot.startIndex(w);
+	// Trigger point at center of display
+	return triggerPtr + scopePointCount - w/2;
+    }
+
+    // Trigger edge detection and state machine, called every time the plot ptr advances.
+    void checkTrigger() {
+	if (triggerMode == TRIGGER_FREERUN || visiblePlots.size() == 0 || plot2d)
+	    return;
+
+	ScopePlot plot = visiblePlots.firstElement();
+	int currentPtr = plot.ptr;
+
+	// Only check when ptr advances (new sample point)
+	if (currentPtr == lastTriggerCheckPtr)
+	    return;
+	lastTriggerCheckPtr = currentPtr;
+
+	double val = (plot.maxValues[currentPtr] + plot.minValues[currentPtr]) * .5;
+
+	boolean edgeCrossing = false;
+	if (triggerEdge == TRIGGER_EDGE_RISING)
+	    edgeCrossing = prevTriggerValue < triggerLevel && val >= triggerLevel;
+	else
+	    edgeCrossing = prevTriggerValue > triggerLevel && val <= triggerLevel;
+
+	switch (triggerState) {
+	case TRIG_STATE_ARMED:
+	    if (edgeCrossing) {
+		triggerState = TRIG_STATE_TRIGGERED;
+		triggerPtr = currentPtr;
+		triggerTime = sim.t;
+		triggerHoldoff = 0;
+		triggerWaiting = false;
+		hasTriggerFired = true;
+	    } else {
+		triggerWaiting = true;
+		if (triggerMode == TRIGGER_AUTO) {
+		    triggerHoldoff++;
+		    if (triggerHoldoff >= triggerAutoTimeout) {
+			triggerState = TRIG_STATE_AUTO_RUN;
+			triggerWaiting = false;
+		    }
+		}
+	    }
+	    break;
+
+	case TRIG_STATE_TRIGGERED:
+	    triggerHoldoff++;
+	    if (triggerHoldoff >= rect.width) {
+		triggerState = TRIG_STATE_ARMED;
+		triggerHoldoff = 0;
+	    }
+	    break;
+
+	case TRIG_STATE_AUTO_RUN:
+	    if (edgeCrossing) {
+		triggerState = TRIG_STATE_TRIGGERED;
+		triggerPtr = currentPtr;
+		triggerTime = sim.t;
+		triggerHoldoff = 0;
+		hasTriggerFired = true;
+	    }
+	    break;
+	}
+
+	prevTriggerValue = val;
+    }
+
+    void setTriggerMode(int mode) {
+	triggerMode = mode;
+	triggerState = TRIG_STATE_ARMED;
+	triggerHoldoff = 0;
+	triggerWaiting = false;
+	hasTriggerFired = false;
+	lastTriggerCheckPtr = -1;
+	resetGraph();
+    }
+
+    // Draw trigger indicator: dashed level line, edge arrow, and status text
+    void drawTriggerIndicator(Graphics g) {
+	if (triggerMode == TRIGGER_FREERUN || visiblePlots.size() == 0)
+	    return;
+
+	ScopePlot plot = visiblePlots.firstElement();
+	int maxy = (rect.height-1)/2;
+
+	// Calculate y position of trigger level line
+	int trigY = maxy - (int)((triggerLevel + plot.plotOffset) * plot.gridMult);
+
+	// Draw trigger level line (dashed, orange)
+	if (trigY >= 0 && trigY < rect.height) {
+	    g.setColor("#FF8000");
+	    for (int x = 0; x < rect.width; x += 8) {
+		int x2 = Math.min(x + 4, rect.width - 1);
+		g.drawLine(x, trigY, x2, trigY);
+	    }
+
+	    // Draw edge indicator
+	    String edgeText = triggerEdge == TRIGGER_EDGE_RISING ? "T\u2191" : "T\u2193";
+	    g.drawString(edgeText, rect.width - 25, trigY - 3);
+	}
+
+	// Draw trigger status text
+	String statusText;
+	switch (triggerState) {
+	case TRIG_STATE_ARMED:
+	    statusText = triggerWaiting ? "WAIT" : "ARMED";
+	    break;
+	case TRIG_STATE_TRIGGERED:
+	    statusText = "TRIG";
+	    break;
+	case TRIG_STATE_AUTO_RUN:
+	    statusText = "AUTO";
+	    break;
+	default:
+	    statusText = "";
+	}
+	g.setColor("#FF8000");
+	int sw = (int)g.context.measureText(statusText).getWidth();
+	g.drawString(statusText, rect.width - sw - 5, rect.height - 5);
+    }
+
     void initialize() {
     	resetGraph();
     	scale[UNITS_W] = scale[UNITS_OHMS] = scale[UNITS_V] = 5;
@@ -580,6 +754,8 @@ class Scope {
 	int i;
 	for (i = 0; i != plots.size(); i++)
 	    plots.get(i).timeStep();
+
+	checkTrigger();
 
 	int x=0;
 	int y=0;
@@ -985,7 +1161,8 @@ class Scope {
     	// draw selection on top.  only works if selection chosen from scope
     	if (selectedPlot >= 0 && selectedPlot < visiblePlots.size())
     	    drawPlot(g, visiblePlots.get(selectedPlot), allPlotsSameUnits, true, sel);
-    	
+
+    	drawTriggerIndicator(g);
         drawInfoTexts(g);
     	
     	g.restore();
@@ -1014,7 +1191,7 @@ class Scope {
     	    ScopePlot plot = visiblePlots.get(si);
     	    if (plot.units != units)
     		continue;
-    	    int ipa = plot.startIndex(rect.width);
+    	    int ipa = displayStartIndex(plot, rect.width);
     	    double maxV[] = plot.maxValues;
     	    double minV[] = plot.minValues;
     	    for (i = 0; i != rect.width; i++) {
@@ -1032,7 +1209,7 @@ class Scope {
 	if (manualScale)
 	    return;
     	int i;
-    	int ipa = plot.startIndex(rect.width);
+    	int ipa = displayStartIndex(plot, rect.width);
     	double maxV[] = plot.maxValues;
     	double minV[] = plot.minValues;
     	double max = 0;
@@ -1086,7 +1263,7 @@ class Scope {
     	    color = CircuitElm.selectColor.getHexValue();
 	else if (selected)
 	    color = plot.color;
-    	int ipa = plot.startIndex(rect.width);
+    	int ipa = displayStartIndex(plot, rect.width);
     	double maxV[] = plot.maxValues;
     	double minV[] = plot.minValues;
     	double gridMax;
@@ -1166,8 +1343,9 @@ class Scope {
     	    }
     	    
     	    // vertical gridlines
-    	    double tstart = sim.t-sim.maxTimeStep*speed*rect.width;
-    	    double tx = sim.t-(sim.t % gridStepX);
+    	    double tRight = isTriggered() ? triggerTime + sim.maxTimeStep*speed*rect.width/2 : sim.t;
+    	    double tstart = tRight-sim.maxTimeStep*speed*rect.width;
+    	    double tx = tRight-(tRight % gridStepX);
 
     	    for (int ll = 0; ; ll++) {
     		double tl = tx-gridStepX*ll;
@@ -1241,6 +1419,8 @@ class Scope {
 	    return;
 	if (plot2d || visiblePlots.size() == 0)
 	    cursorTime = -1;
+	else if (isTriggered())
+	    cursorTime = triggerTime + sim.maxTimeStep*speed*(mouseX - rect.x - rect.width/2);
 	else
 	    cursorTime = sim.t-sim.maxTimeStep*speed*(rect.x+rect.width-mouseX);
     	checkForSelection(mouseX, mouseY);
@@ -1259,7 +1439,7 @@ class Scope {
 	    selectedPlot = -1;
 	    return;
 	}
-	int ipa = plots.get(0).startIndex(rect.width);
+	int ipa = displayStartIndex(plots.get(0), rect.width);
 	int ip = (mouseX-rect.x+ipa) & (scopePointCount-1);
     	int maxy = (rect.height-1)/2;
     	int y = maxy;
@@ -1289,9 +1469,12 @@ class Scope {
 	int cursorX = -1;
 	int ct = 0;
 	if (cursorTime >= 0) {
-	    cursorX = -(int) ((sim.t-cursorTime)/(sim.maxTimeStep*speed) - rect.x - rect.width);
+	    if (isTriggered())
+		cursorX = (int)(rect.x + rect.width/2 + (cursorTime - triggerTime) / (sim.maxTimeStep*speed));
+	    else
+		cursorX = -(int) ((sim.t-cursorTime)/(sim.maxTimeStep*speed) - rect.x - rect.width);
 	    if (cursorX >= rect.x) {
-		int ipa = plots.get(0).startIndex(rect.width);
+		int ipa = displayStartIndex(plots.get(0), rect.width);
 		int ip = (cursorX-rect.x+ipa) & (scopePointCount-1);
 		int maxy = (rect.height-1)/2;
 		int y = maxy;
@@ -1373,12 +1556,12 @@ class Scope {
 	ScopePlot plot = visiblePlots.firstElement();
 	int i;
 	double avg = 0;
-    	int ipa = plot.ptr+scopePointCount-rect.width;
+    	int ipa = displayStartIndex(plot, rect.width);
     	double maxV[] = plot.maxValues;
     	double minV[] = plot.minValues;
     	double mid = (maxValue+minValue)/2;
 	int state = -1;
-	
+
 	// skip zeroes
 	for (i = 0; i != rect.width; i++) {
 	    int ip = (i+ipa) & (scopePointCount-1);
@@ -1396,17 +1579,17 @@ class Scope {
 	for (; i != rect.width; i++) {
 	    int ip = (i+ipa) & (scopePointCount-1);
 	    boolean sw = false;
-	    
+
 	    // switching polarity?
 	    if (state == 1) {
 		if (maxV[ip] < mid)
 		    sw = true;
 	    } else if (minV[ip] > mid)
 		sw = true;
-	    
+
 	    if (sw) {
 		state = -state;
-		
+
 		// completed a full cycle?
 		if (firstState == state) {
 		    if (waveCount == 0) {
@@ -1430,7 +1613,7 @@ class Scope {
 	    drawInfoText(g, plot.getUnitText(rms) + "rms");
 	}
     }
-    
+
     void drawScale(ScopePlot plot, Graphics g) {
     	    if (!isManualScale()) {
         	    if ( gridStepY!=0 && (!(showV && showI))) {
@@ -1475,7 +1658,7 @@ class Scope {
 	ScopePlot plot = visiblePlots.firstElement();
 	int i;
 	double avg = 0;
-    	int ipa = plot.ptr+scopePointCount-rect.width;
+    	int ipa = displayStartIndex(plot, rect.width);
     	double maxV[] = plot.maxValues;
     	double minV[] = plot.minValues;
     	double mid = (maxValue+minValue)/2;
@@ -1535,7 +1718,7 @@ class Scope {
     void drawDutyCycle(Graphics g) {
 	ScopePlot plot = visiblePlots.firstElement();
 	int i;
-    	int ipa = plot.ptr+scopePointCount-rect.width;
+    	int ipa = displayStartIndex(plot, rect.width);
     	double maxV[] = plot.maxValues;
     	double minV[] = plot.minValues;
     	double mid = (maxValue+minValue)/2;
@@ -1597,7 +1780,7 @@ class Scope {
 	double avg = 0;
 	int i;
 	ScopePlot plot = visiblePlots.firstElement();
-    	int ipa = plot.ptr+scopePointCount-rect.width;
+    	int ipa = displayStartIndex(plot, rect.width);
     	double minV[] = plot.minValues;
     	double maxV[] = plot.maxValues;
 	for (i = 0; i != rect.width; i++) {
@@ -1818,6 +2001,11 @@ class Scope {
 
 	if (isManualScale())
 	    flags |= FLAG_DIVISIONS;
+	if (triggerMode != TRIGGER_FREERUN) {
+	    flags |= FLAG_TRIGGER;
+	    flags |= (triggerMode << 23);
+	    flags |= (triggerEdge << 25);
+	}
 	return flags;
     }
     
@@ -1840,6 +2028,8 @@ class Scope {
     			plots.size();
 	if ((flags & FLAG_DIVISIONS) != 0)
 	    x += " " + manDivisions;
+	if ((flags & FLAG_TRIGGER) != 0)
+	    x += " " + triggerLevel;
     	int i;
     	for (i = 0; i < plots.size(); i++) {
     	    ScopePlot p = plots.get(i);
@@ -1895,6 +2085,8 @@ class Scope {
 		manDivisions = 8;
 		if ((flags & FLAG_DIVISIONS) != 0)
 		    manDivisions = lastManDivisions = Integer.parseInt(st.nextToken());
+		if ((flags & FLAG_TRIGGER) != 0)
+		    triggerLevel = Double.parseDouble(st.nextToken());
     		int i;
     		int u = ce.getScopeUnits(value);
 		if (u > UNITS_A)
@@ -1984,6 +2176,13 @@ class Scope {
     	logSpectrum = (flags & 65536) != 0;
     	showAverage = (flags & (1<<17)) != 0;
     	showElmInfo = (flags & (1<<20)) != 0;
+    	if ((flags & FLAG_TRIGGER) != 0) {
+    	    triggerMode = (flags >> 23) & 3;
+    	    triggerEdge = (flags >> 25) & 1;
+    	} else {
+    	    triggerMode = TRIGGER_FREERUN;
+    	    triggerEdge = TRIGGER_EDGE_RISING;
+    	}
     }
     
     void saveAsDefault() {
@@ -1992,9 +2191,12 @@ class Scope {
             return;
 	ScopePlot vPlot = plots.get(0);
     	int flags = getFlags();
-    	
+
     	// store current scope settings as default.  1 is a version code
-    	stor.setItem("scopeDefaults", "1 " + flags + " " + vPlot.scopePlotSpeed);
+    	String s = "1 " + flags + " " + vPlot.scopePlotSpeed;
+    	if ((flags & FLAG_TRIGGER) != 0)
+    	    s += " " + triggerLevel;
+    	stor.setItem("scopeDefaults", s);
     	CirSim.console("saved defaults " + flags);
     }
 
@@ -2009,6 +2211,8 @@ class Scope {
         int flags = Integer.parseInt(arr[1]);
         setFlags(flags);
         speed = Integer.parseInt(arr[2]);
+        if (arr.length > 3 && (flags & FLAG_TRIGGER) != 0)
+            triggerLevel = Double.parseDouble(arr[3]);
         return true;
     }
     

--- a/src/com/lushprojects/circuitjs1/client/ScopePropertiesDialog.java
+++ b/src/com/lushprojects/circuitjs1/client/ScopePropertiesDialog.java
@@ -64,6 +64,13 @@ Grid grid, vScaleGrid, hScaleGrid;
 int nx, ny;
 Label scopeSpeedLabel, manualScaleLabel,vScaleList, manualScaleId, positionLabel, divisionsLabel;
 expandingLabel vScaleLabel, hScaleLabel;
+// Trigger controls
+RadioButton trigFreeRunButton, trigNormalButton, trigAutoButton;
+RadioButton trigRisingButton, trigFallingButton;
+TextBox triggerLevelTextBox;
+Grid triggerGrid;
+expandingLabel triggerLabel;
+HorizontalPanel trigModep, trigEdgep;
 Vector <Button> chanButtons = new Vector <Button>();
 int plotSelection = 0;
 labelledGridManager gridLabels;
@@ -380,7 +387,86 @@ labelledGridManager gridLabels;
 
 	//	speedGrid.getColumnFormatter().setWidth(0, "40%");
 		fp.add(hScaleGrid);
-		
+
+		// *************** TRIGGER ***********************************************************
+
+		triggerGrid = new Grid(4,4);
+		triggerLabel = new expandingLabel(Locale.LS("Trigger"), false);
+		triggerGrid.setWidget(0, 0, triggerLabel.p);
+
+		trigModep = new HorizontalPanel();
+		trigFreeRunButton = new RadioButton("trigMode", Locale.LS("Free Run"));
+		trigFreeRunButton.addValueChangeHandler(new ValueChangeHandler<Boolean>() {
+		    public void onValueChange(ValueChangeEvent<Boolean> e) {
+			if (e.getValue()) {
+			    scope.setTriggerMode(Scope.TRIGGER_FREERUN);
+			    updateUi();
+			}
+		    }
+		});
+		trigNormalButton = new RadioButton("trigMode", Locale.LS("Normal"));
+		trigNormalButton.addValueChangeHandler(new ValueChangeHandler<Boolean>() {
+		    public void onValueChange(ValueChangeEvent<Boolean> e) {
+			if (e.getValue()) {
+			    scope.setTriggerMode(Scope.TRIGGER_NORMAL);
+			    updateUi();
+			}
+		    }
+		});
+		trigAutoButton = new RadioButton("trigMode", Locale.LS("Auto"));
+		trigAutoButton.addValueChangeHandler(new ValueChangeHandler<Boolean>() {
+		    public void onValueChange(ValueChangeEvent<Boolean> e) {
+			if (e.getValue()) {
+			    scope.setTriggerMode(Scope.TRIGGER_AUTO);
+			    updateUi();
+			}
+		    }
+		});
+		trigModep.add(trigFreeRunButton);
+		trigModep.add(trigNormalButton);
+		trigModep.add(trigAutoButton);
+		triggerGrid.setWidget(1, 0, trigModep);
+
+		trigEdgep = new HorizontalPanel();
+		trigRisingButton = new RadioButton("trigEdge", Locale.LS("Rising"));
+		trigRisingButton.addValueChangeHandler(new ValueChangeHandler<Boolean>() {
+		    public void onValueChange(ValueChangeEvent<Boolean> e) {
+			if (e.getValue()) {
+			    scope.triggerEdge = Scope.TRIGGER_EDGE_RISING;
+			    scope.resetGraph();
+			}
+		    }
+		});
+		trigFallingButton = new RadioButton("trigEdge", Locale.LS("Falling"));
+		trigFallingButton.addValueChangeHandler(new ValueChangeHandler<Boolean>() {
+		    public void onValueChange(ValueChangeEvent<Boolean> e) {
+			if (e.getValue()) {
+			    scope.triggerEdge = Scope.TRIGGER_EDGE_FALLING;
+			    scope.resetGraph();
+			}
+		    }
+		});
+		trigEdgep.add(new Label(Locale.LS("Edge") + ": "));
+		trigEdgep.add(trigRisingButton);
+		trigEdgep.add(trigFallingButton);
+		triggerGrid.setWidget(2, 0, trigEdgep);
+
+		HorizontalPanel trigLevelp = new HorizontalPanel();
+		trigLevelp.add(new Label(Locale.LS("Level") + ": "));
+		triggerLevelTextBox = new TextBox();
+		triggerLevelTextBox.addStyleName("scalebox");
+		trigLevelp.add(triggerLevelTextBox);
+		Button trigApplyButton = new Button(Locale.LS("Apply"));
+		trigApplyButton.addClickHandler(new ClickHandler() {
+		    public void onClick(ClickEvent event) {
+			applyTriggerLevel();
+		    }
+		});
+		trigLevelp.add(trigApplyButton);
+		triggerGrid.setWidget(3, 0, trigLevelp);
+
+		fp.add(triggerGrid);
+
 		// *************** PLOTS ***********************************************************
 		
 		CircuitElm elm = scope.getSingleElm();
@@ -597,6 +683,24 @@ labelledGridManager gridLabels;
 	    
 	    
 
+	    // Trigger section
+	    trigFreeRunButton.setValue(scope.triggerMode == Scope.TRIGGER_FREERUN);
+	    trigNormalButton.setValue(scope.triggerMode == Scope.TRIGGER_NORMAL);
+	    trigAutoButton.setValue(scope.triggerMode == Scope.TRIGGER_AUTO);
+	    boolean trigActive = scope.triggerMode != Scope.TRIGGER_FREERUN;
+	    trigRisingButton.setValue(scope.triggerEdge == Scope.TRIGGER_EDGE_RISING);
+	    trigFallingButton.setValue(scope.triggerEdge == Scope.TRIGGER_EDGE_FALLING);
+	    trigRisingButton.setEnabled(trigActive);
+	    trigFallingButton.setEnabled(trigActive);
+	    triggerLevelTextBox.setText(EditDialog.unitString(null, scope.triggerLevel));
+	    triggerLevelTextBox.setEnabled(trigActive);
+	    // Show/hide trigger details based on section expansion
+	    trigModep.setVisible(triggerLabel.expanded);
+	    trigEdgep.setVisible(triggerLabel.expanded && trigActive);
+	    triggerGrid.getRowFormatter().setVisible(1, triggerLabel.expanded);
+	    triggerGrid.getRowFormatter().setVisible(2, triggerLabel.expanded && trigActive);
+	    triggerGrid.getRowFormatter().setVisible(3, triggerLabel.expanded && trigActive);
+
 	    // if you add more here, make sure it still works with transistor scopes
 	}
 	
@@ -698,6 +802,15 @@ labelledGridManager gridLabels;
 		int n = getDivisionsValue();
 		if (n > 0)
 		    scope.setManDivisions(n);
+	    }
+	}
+
+	void applyTriggerLevel() {
+	    try {
+		double d = EditDialog.parseUnits(triggerLevelTextBox.getText());
+		scope.triggerLevel = d;
+		scope.resetGraph();
+	    } catch (Exception e) {
 	    }
 	}
 


### PR DESCRIPTION
## Summary

- Adds **trigger mode** to the oscilloscope for stable display of periodic signals, as requested in #194
- Three modes: **Free Run** (current behavior, no regression), **Normal** (freezes on edge crossing), **Auto** (falls back to free-run if no trigger within timeout)
- Rising/falling edge detection with configurable trigger level
- Visual feedback: orange dashed trigger level line, edge indicator, status text (WAIT/TRIG/AUTO/ARMED)
- Trigger point displayed at center of scope window with time gridlines anchored to trigger
- Full backward-compatible serialization via FLAG_TRIGGER bit
- UI controls added to Scope Properties dialog as a collapsible Trigger section

## How it works

A 3-state machine (ARMED, TRIGGERED, re-arm) detects edge crossings on the first visible plot. When triggered, the display anchors to the trigger point instead of scrolling continuously. In Auto mode, if no trigger is detected within a timeout period, the scope falls back to free-running to ensure the display does not freeze indefinitely.

## Test plan

- [ ] Free Run mode behaves identically to current scope (no regression)
- [ ] Normal trigger with sine source: set rising edge at 0V, stable repeating waveform
- [ ] Auto trigger: set level unreachably high, free-runs after timeout; set reasonable level, triggers
- [ ] Falling edge trigger works correctly
- [ ] Visual indicators: orange trigger line, edge arrow, status text visible
- [ ] Save/reload circuit preserves trigger settings
- [ ] Multiple scope traces lock to same trigger point
- [ ] Trigger level text box accepts unit suffixes (e.g. 100m for 100mV)

Generated with [Claude Code](https://claude.com/claude-code)