### PR TITLE
Toolbar enhancements: file ops, separators, centre, mode display

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/Menus.java
+++ b/src/com/lushprojects/circuitjs1/client/Menus.java
@@ -61,6 +61,7 @@ public class Menus {
     CheckboxMenuItem noEditCheckItem;
     CheckboxMenuItem mouseWheelEditCheckItem;
     CheckboxMenuItem toolbarCheckItem;
+    CheckboxMenuItem mouseModeCheckItem;
     MenuBar elmMenuBar;
     MenuItem elmEditMenuItem;
     MenuItem elmCutMenuItem;
@@ -215,12 +216,18 @@ public class Menus {
 		    sim.setToolbar();
 		}
 	}));
+	m.addItem(mouseModeCheckItem = new CheckboxMenuItem(Locale.LS("Show Mode"),
+		new Command() { public void execute(){
+			sim.setOptionInStorage("showMouseMode", mouseModeCheckItem.getState());
+		}
+	}));
+	mouseModeCheckItem.setState(sim.getOptionFromStorage("showMouseMode", true));
 	m.addItem(crossHairCheckItem = new CheckboxMenuItem(Locale.LS("Show Cursor Cross Hairs"),
 		new Command() { public void execute(){
 		    sim.setOptionInStorage("crossHair", crossHairCheckItem.getState());
 		}
 	}));
-	
+
 	m.addItem(euroResistorCheckItem = new CheckboxMenuItem(Locale.LS("European Resistors")));
 	m.addItem(euroGatesCheckItem = new CheckboxMenuItem(Locale.LS("IEC Gates")));
 	m.addItem(printableCheckItem = new CheckboxMenuItem(Locale.LS("White Background")));

--- a/src/com/lushprojects/circuitjs1/client/Toolbar.java
+++ b/src/com/lushprojects/circuitjs1/client/Toolbar.java
@@ -21,7 +21,7 @@ public class Toolbar extends FlowPanel {
     private Label modeLabel;
     private HashMap<String, Label> highlightableButtons = new HashMap<>();
     private Label activeButton;  // Currently active button
-    private String SEPARATOR = "<div style=\"height:30px;width:0;border-left:2px solid grey;\"></div>";
+    private String SEPARATOR = "<div style=\"height:30px;width:0;border-left:2px solid grey;margin:0 8px;\"></div>";
 
     Label resistorButton;
 

--- a/src/com/lushprojects/circuitjs1/client/Toolbar.java
+++ b/src/com/lushprojects/circuitjs1/client/Toolbar.java
@@ -21,6 +21,7 @@ public class Toolbar extends FlowPanel {
     private Label modeLabel;
     private HashMap<String, Label> highlightableButtons = new HashMap<>();
     private Label activeButton;  // Currently active button
+    private String SEPARATOR = "<div style=\"height:30px;width:0;border-left:2px solid grey;\"></div>";
 
     Label resistorButton;
 
@@ -35,18 +36,32 @@ public class Toolbar extends FlowPanel {
         style.setDisplay(Style.Display.FLEX);
 	style.setProperty("alignItems", "center");
 
+	add(createIconButton("doc-new", "New Blank Circuit", new MyCommand("file", "newblankcircuit")));
+	add(createIconButton("folder",  "Open File...", new MyCommand("file", "importfromlocalfile")));
+	if (CirSim.isElectron()) {
+		// Additional conditions are required: "Save" should not be available always.
+		//add(createIconButton("floppy", "Save", new MyCommand("file", "save")));
+		add(createIconButton("floppy", "Save As...", new MyCommand("file", "saveas")));
+	} else {
+		add(createIconButton("floppy", "Save As...", new MyCommand("file", "exportaslocalfile")));
+	}
+	add(new HTML("<sup style=\"margin-left:-12px;\"><strong>+</strong></sup>")); // add symbol to "Save As" icon for the visual difference
+	add(new HTML(SEPARATOR));
 	add(createIconButton("ccw", "Undo", new MyCommand("edit", "undo")));
 	add(createIconButton("cw",  "Redo", new MyCommand("edit", "redo")));
+	add(new HTML(SEPARATOR));
 	add(createIconButton("scissors", "Cut", new MyCommand("edit", "cut")));
 	add(createIconButton("copy", "Copy", new MyCommand("edit", "copy")));
 	add(createIconButton("paste", "Paste", new MyCommand("edit", "paste")));
 	add(createIconButton("clone", "Duplicate", new MyCommand("edit", "duplicate")));
+	add(new HTML(SEPARATOR));
 	add(createIconButton("search", "Find Component...", new MyCommand("edit", "search")));
-
+	add(new HTML(SEPARATOR));
+	add(createIconButton("target", "Centre Circuit", new MyCommand("edit", "centrecircuit")));
 	add(createIconButton("zoom-11", "Zoom 100%", new MyCommand("zoom", "zoom100")));
 	add(createIconButton("zoom-in", "Zoom In", new MyCommand("zoom", "zoomin")));
 	add(createIconButton("zoom-out", "Zoom Out", new MyCommand("zoom", "zoomout")));
-
+	add(new HTML(SEPARATOR));
 	add(createIconButton(wireIcon, "WireElm"));
 	add(resistorButton = createIconButton(resistorIcon, "ResistorElm"));
 	add(createIconButton(groundIcon, "GroundElm"));

--- a/src/com/lushprojects/circuitjs1/client/UIManager.java
+++ b/src/com/lushprojects/circuitjs1/client/UIManager.java
@@ -749,10 +749,13 @@ public class UIManager {
             }
         }
 
-        // Add info about mouse mode in graphics
+        // Add info about mouse mode in graphics; drop below subcircuit/context bar when visible
         if (menus.mouseModeCheckItem.getState()){
             if (menus.printableCheckItem.getState()) g.setColor(Color.black);
-            g.drawString(Locale.LS("Mode: ") + app.classToLabelMap.get(mouseModeStr), 10, 29);
+            int modeY = 29;
+            if (!subcircuitStack.isEmpty() || app.isEditingContext())
+                modeY += subcircuitBar.getOffsetHeight();
+            g.drawString(Locale.LS("Mode: ") + app.classToLabelMap.get(mouseModeStr), 10, modeY);
         }
 
 	try {

--- a/src/com/lushprojects/circuitjs1/client/UIManager.java
+++ b/src/com/lushprojects/circuitjs1/client/UIManager.java
@@ -732,7 +732,7 @@ public class UIManager {
         perfmon.stopContext(); // updateCircuit
 
         if (app.developerMode) {
-            int height = 15;
+            int height = 45;
             int increment = 15;
             g.drawString("Framerate: " + CircuitElm.showFormat.format(framerate), 10, height);
             g.drawString("Steprate: " + CircuitElm.showFormat.format(steprate), 10, height += increment);
@@ -747,6 +747,12 @@ public class UIManager {
             for (int x = 0; x < splits.length; x++) {
                 g.drawString(splits[x], 10, height + (increment * x));
             }
+        }
+
+        // Add info about mouse mode in graphics
+        if (menus.mouseModeCheckItem.getState()){
+            if (menus.printableCheckItem.getState()) g.setColor(Color.black);
+            g.drawString(Locale.LS("Mode: ") + app.classToLabelMap.get(mouseModeStr), 10, 29);
         }
 
 	try {


### PR DESCRIPTION
## Summary
Rebased onto `v3-dev` (replaces #212 which targeted master). Originally based on @SEVA77's PR #162.

- Adds file operation buttons (New, Open, Save As) to toolbar with separators between logical groups
- Adds Centre Circuit button to toolbar
- Adds "Show Mode" checkbox in Options menu to display current mouse mode on canvas
- Developer mode info shifted down to avoid overlap with mode display

## Changes from master version
- Re-implemented directly against v3-dev architecture (Menus.java, UIManager.java, Toolbar.java)
- CirSim.java code remapped to appropriate manager classes

## Test plan
- [ ] Verify toolbar shows file buttons, separators, and centre button
- [ ] Verify New/Open/Save As toolbar buttons work
- [ ] Verify Options → Show Mode toggles mode text on canvas
- [ ] Verify mode text appears in correct position without overlapping other UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
