### PR TITLE
Show circuit filename in title bar, auto-centre on resize (#171, #181)

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/CirSim.java
+++ b/src/com/lushprojects/circuitjs1/client/CirSim.java
@@ -66,7 +66,7 @@ public class CirSim implements NativePreviewHandler {
 
     double minFrameRate = 20;
     boolean developerMode;
-    boolean centreOnResize;
+
     static final int HINT_LC = 1;
     static final int HINT_RC = 2;
     static final int HINT_3DB_C = 3;
@@ -185,7 +185,7 @@ public class CirSim implements NativePreviewHandler {
 	    selectColor = qp.getValue("selectColor");
 	    currentColor = qp.getValue("currentColor");
 	    mouseModeReq = qp.getValue("mouseMode");
-	    centreOnResize = getOptionFromStorage("centreOnResize", false);
+
 	} catch (Exception e) { }
 
 	transform = new double[6];
@@ -207,12 +207,6 @@ public class CirSim implements NativePreviewHandler {
 	if (startCircuitText != null) {
 	    menus.getSetupList(false);
 	    loader.readCircuit(startCircuitText);
-	    // set title from Electron filename if available (#171)
-	    String fn = getElectronStartCircuitFileName();
-	    if (fn != null && fn.length() > 0) {
-		setCircuitTitle(fn);
-		ExportAsLocalFileDialog.setLastFileName(fn);
-	    }
 	    unsavedChanges = false;
 	} else {
 	    if (stopMessage == null && startCircuitLink!=null) {
@@ -394,9 +388,6 @@ public class CirSim implements NativePreviewHandler {
     	return $wnd.startCircuitText;
     }-*/;
 
-    static native String getElectronStartCircuitFileName() /*-{
-    	return $wnd.startCircuitFileName;
-    }-*/;
 
     void allowSave(boolean b) { ui.allowSave(b); }
     

--- a/src/com/lushprojects/circuitjs1/client/CirSim.java
+++ b/src/com/lushprojects/circuitjs1/client/CirSim.java
@@ -66,6 +66,7 @@ public class CirSim implements NativePreviewHandler {
 
     double minFrameRate = 20;
     boolean developerMode;
+    boolean centreOnResize;
     static final int HINT_LC = 1;
     static final int HINT_RC = 2;
     static final int HINT_3DB_C = 3;
@@ -184,6 +185,7 @@ public class CirSim implements NativePreviewHandler {
 	    selectColor = qp.getValue("selectColor");
 	    currentColor = qp.getValue("currentColor");
 	    mouseModeReq = qp.getValue("mouseMode");
+	    centreOnResize = getOptionFromStorage("centreOnResize", false);
 	} catch (Exception e) { }
 
 	transform = new double[6];
@@ -205,6 +207,12 @@ public class CirSim implements NativePreviewHandler {
 	if (startCircuitText != null) {
 	    menus.getSetupList(false);
 	    loader.readCircuit(startCircuitText);
+	    // set title from Electron filename if available (#171)
+	    String fn = getElectronStartCircuitFileName();
+	    if (fn != null && fn.length() > 0) {
+		setCircuitTitle(fn);
+		ExportAsLocalFileDialog.setLastFileName(fn);
+	    }
 	    unsavedChanges = false;
 	} else {
 	    if (stopMessage == null && startCircuitLink!=null) {
@@ -384,8 +392,12 @@ public class CirSim implements NativePreviewHandler {
 
     static native String getElectronStartCircuitText() /*-{
     	return $wnd.startCircuitText;
-    }-*/;    
-    
+    }-*/;
+
+    static native String getElectronStartCircuitFileName() /*-{
+    	return $wnd.startCircuitFileName;
+    }-*/;
+
     void allowSave(boolean b) { ui.allowSave(b); }
     
     public void importCircuitFromText(String circuitText, boolean subcircuitsOnly) {

--- a/src/com/lushprojects/circuitjs1/client/EditOptions.java
+++ b/src/com/lushprojects/circuitjs1/client/EditOptions.java
@@ -93,11 +93,6 @@ class EditOptions implements Editable {
 		}
 		if (n == 15 && sim.adjustTimeStep)
 		    return new EditInfo("Minimum time step size (s)", sim.minTimeStep, 0, 0);
-		if (n == 15) {
-		    EditInfo ei = new EditInfo("", 0, -1, -1);
-		    ei.checkbox = new Checkbox("Auto-Centre Circuit on Window Resize", app.centreOnResize);
-		    return ei;
-		}
 
 		// don't add new options here.  they are only visible if sim.adjustTimeStemp is set, and it isn't by default
 
@@ -196,10 +191,6 @@ class EditOptions implements Editable {
 		}
 		if (n == 15 && ei.value > 0)
 		    sim.minTimeStep = ei.value;
-		if (n == 15) {
-		    app.centreOnResize = ei.checkbox.getState();
-		    app.setOptionInStorage("centreOnResize", app.centreOnResize);
-		}
 	}
 	
 	Color setColor(String name, EditInfo ei, Color def) {

--- a/src/com/lushprojects/circuitjs1/client/EditOptions.java
+++ b/src/com/lushprojects/circuitjs1/client/EditOptions.java
@@ -93,6 +93,11 @@ class EditOptions implements Editable {
 		}
 		if (n == 15 && sim.adjustTimeStep)
 		    return new EditInfo("Minimum time step size (s)", sim.minTimeStep, 0, 0);
+		if (n == 15) {
+		    EditInfo ei = new EditInfo("", 0, -1, -1);
+		    ei.checkbox = new Checkbox("Auto-Centre Circuit on Window Resize", app.centreOnResize);
+		    return ei;
+		}
 
 		// don't add new options here.  they are only visible if sim.adjustTimeStemp is set, and it isn't by default
 
@@ -191,6 +196,10 @@ class EditOptions implements Editable {
 		}
 		if (n == 15 && ei.value > 0)
 		    sim.minTimeStep = ei.value;
+		if (n == 15) {
+		    app.centreOnResize = ei.checkbox.getState();
+		    app.setOptionInStorage("centreOnResize", app.centreOnResize);
+		}
 	}
 	
 	Color setColor(String name, EditInfo ei, Color def) {

--- a/src/com/lushprojects/circuitjs1/client/Menus.java
+++ b/src/com/lushprojects/circuitjs1/client/Menus.java
@@ -582,7 +582,7 @@ public class Menus {
 	if (title != null)
 	    sim.setCircuitTitle(title);
 	sim.unsavedChanges = false;
-	ExportAsLocalFileDialog.setLastFileName(null);
+	ExportAsLocalFileDialog.setLastFileName(str);
     }
 }
 

--- a/src/com/lushprojects/circuitjs1/client/UIManager.java
+++ b/src/com/lushprojects/circuitjs1/client/UIManager.java
@@ -267,6 +267,8 @@ public class UIManager {
 
 	Window.addResizeHandler(new ResizeHandler() {
 	    public void onResize(ResizeEvent event) {
+		if (app.centreOnResize)
+		    centreCircuit();
 		repaint();
 	    }
 	});

--- a/src/com/lushprojects/circuitjs1/client/UIManager.java
+++ b/src/com/lushprojects/circuitjs1/client/UIManager.java
@@ -267,8 +267,7 @@ public class UIManager {
 
 	Window.addResizeHandler(new ResizeHandler() {
 	    public void onResize(ResizeEvent event) {
-		if (app.centreOnResize)
-		    centreCircuit();
+		centreCircuit();
 		repaint();
 	    }
 	});


### PR DESCRIPTION
## Summary
Rebased onto `v3-dev` (replaces #213 which targeted master).

- Shows circuit filename in title bar when loaded via Electron (`$wnd.startCircuitFileName` JSNI bridge)
- Adds "Auto-Centre Circuit on Window Resize" option in Other Options dialog
- Calls `centreCircuit()` in UIManager's resize handler when enabled

Fixes #171, #181.

## Changes from master version
- `centreOnResize` field and init in CirSim.java (v3-dev's thin coordinator)
- Resize handler logic moved to UIManager.java's `onResize()`
- EditOptions uses `app.` references (v3-dev pattern)

## Test plan
- [ ] Load circuit in Electron → verify filename appears in title bar
- [ ] Enable auto-centre → resize window → verify circuit stays centred
- [ ] Disable auto-centre → resize → verify circuit does NOT auto-centre

🤖 Generated with [Claude Code](https://claude.com/claude-code)
