### PR TITLE
Optocoupler CTR, SRAM reset restore, voltage-limited current source, macOS paste

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -12,7 +12,38 @@ const url = require('url')
 // be closed automatically when the JavaScript object is garbage collected.
 var windows = [];
 
-Menu.setApplicationMenu(false);
+// Build a minimal application menu so that standard keyboard shortcuts
+// (Cmd+C, Cmd+V, Cmd+X, Cmd+A) work in text fields on macOS.
+// Setting the menu to false disables these shortcuts entirely.
+var template = [
+  {
+    label: 'Edit',
+    submenu: [
+      { role: 'undo' },
+      { role: 'redo' },
+      { type: 'separator' },
+      { role: 'cut' },
+      { role: 'copy' },
+      { role: 'paste' },
+      { role: 'selectAll' }
+    ]
+  }
+];
+if (process.platform === 'darwin') {
+  template.unshift({
+    label: app.getName(),
+    submenu: [
+      { role: 'about' },
+      { type: 'separator' },
+      { role: 'hide' },
+      { role: 'hideOthers' },
+      { role: 'unhide' },
+      { type: 'separator' },
+      { role: 'quit' }
+    ]
+  });
+}
+Menu.setApplicationMenu(Menu.buildFromTemplate(template));
 
 // save arguments
 global.sharedObject = {prop1: process.argv};

--- a/src/com/lushprojects/circuitjs1/client/CurrentElm.java
+++ b/src/com/lushprojects/circuitjs1/client/CurrentElm.java
@@ -23,7 +23,10 @@ package com.lushprojects.circuitjs1.client;
 import com.google.gwt.xml.client.Document;
 
 class CurrentElm extends CircuitElm {
+	static final int FLAG_VOLTAGE_LIMIT = 1;
 	double currentValue;
+	double maxVoltage = 1e8;
+	double lastVoltDiff;
 	boolean broken;
 	public CurrentElm(int xx, int yy) {
 	    super(xx, yy);
@@ -34,22 +37,32 @@ class CurrentElm extends CircuitElm {
 	    super(xa, ya, xb, yb, f);
 	    try {
 		currentValue = new Double(st.nextToken()).doubleValue();
-	    } catch (Exception e) {
+		maxVoltage = new Double(st.nextToken()).doubleValue();
+	    } catch (Exception e) {}
+	    if (currentValue == 0)
 		currentValue = .01;
-	    }
+	}
+	boolean isVoltageLimited() { return (flags & FLAG_VOLTAGE_LIMIT) != 0; }
+	boolean nonLinear() { return isVoltageLimited(); }
+	void reset() {
+	    super.reset();
+	    lastVoltDiff = 0;
 	}
 	String dump() {
-	    return super.dump() + " " + currentValue;
+	    return super.dump() + " " + currentValue + " " + maxVoltage;
 	}
 
 	void dumpXml(Document doc, Element elem) {
 	    super.dumpXml(doc, elem);
 	    XMLSerializer.dumpAttr(elem, "cu", currentValue);
+	    if (isVoltageLimited())
+		XMLSerializer.dumpAttr(elem, "mv", maxVoltage);
 	}
 
 	void undumpXml(XMLDeserializer xml) {
 	    super.undumpXml(xml);
 	    currentValue = xml.parseDoubleAttr("cu", currentValue);
+	    maxVoltage = xml.parseDoubleAttr("mv", maxVoltage);
 	}
 	int getDumpType() { return 'i'; }
 	
@@ -95,25 +108,67 @@ class CurrentElm extends CircuitElm {
 		// no current path; stamping a current source would cause a matrix error.
 		sim.stampResistor(nodes[0], nodes[1], 1e8);
 		current = 0;
+	    } else if (isVoltageLimited()) {
+		// voltage-limited mode: stamp as nonlinear, doStep() will handle it
+		sim.stampNonLinear(nodes[0]);
+		sim.stampNonLinear(nodes[1]);
 	    } else {
 		// ok to stamp a current source
 		sim.stampCurrentSource(nodes[0], nodes[1], currentValue);
 		current = currentValue;
 	    }
 	}
+
+	void doStep() {
+	    if (!isVoltageLimited() || broken)
+		return;
+	    double vd = volts[1] - volts[0];
+	    if (Math.abs(lastVoltDiff - vd) > .01)
+		sim.converged = false;
+	    lastVoltDiff = vd;
+
+	    double absVd = Math.abs(vd);
+	    if (absVd <= maxVoltage) {
+		// within compliance: act as ideal current source
+		sim.stampResistor(nodes[0], nodes[1], 1e8);
+		sim.stampCurrentSource(nodes[0], nodes[1], currentValue);
+		current = currentValue;
+	    } else {
+		// beyond compliance: act as high-impedance (open circuit)
+		sim.stampResistor(nodes[0], nodes[1], 1e8);
+		current = vd / 1e8;
+	    }
+	}
 	
 	public EditInfo getEditInfo(int n) {
 	    if (n == 0)
 		return new EditInfo("Current (A)", currentValue, 0, .1);
+	    if (n == 1) {
+		EditInfo ei = new EditInfo("", 0, -1, -1);
+		ei.checkbox = new Checkbox("Voltage Limited",
+		    isVoltageLimited());
+		return ei;
+	    }
+	    if (n == 2 && isVoltageLimited())
+		return new EditInfo("Max Voltage (V)", maxVoltage, 0, 0);
 	    return null;
 	}
 	public void setEditValue(int n, EditInfo ei) {
-	    currentValue = ei.value;
+	    if (n == 0)
+		currentValue = ei.value;
+	    if (n == 1) {
+		flags = ei.changeFlag(flags, FLAG_VOLTAGE_LIMIT);
+		ei.newDialog = true;
+	    }
+	    if (n == 2 && ei.value > 0)
+		maxVoltage = ei.value;
 	}
 	void getInfo(String arr[]) {
 	    arr[0] = "current source";
 	    int i = getBasicInfo(arr);
             arr[i++] = "P = " + getUnitText(getPower(), "W");
+	    if (isVoltageLimited())
+		arr[i++] = "Vmax = " + getVoltageText(maxVoltage);
 	}
 	double getVoltageDiff() {
 	    return volts[1] - volts[0];

--- a/src/com/lushprojects/circuitjs1/client/OptocouplerElm.java
+++ b/src/com/lushprojects/circuitjs1/client/OptocouplerElm.java
@@ -4,6 +4,7 @@ public class OptocouplerElm extends CompositeElm {
     int csize, cspc, cspc2;
     int rectPointsX[], rectPointsY[];
     double curCounts[];
+    double ctr = 1.0; // current transfer ratio (1.0 = 100%)
 
     private static String modelString = "DiodeElm 6 1\rCCCSElm 1 2 3 4\rNTransistorElm 3 4 5";
     private static int[] modelExternalNodes = { 6, 2, 4, 5 };
@@ -21,11 +22,16 @@ public class OptocouplerElm extends CompositeElm {
 	// pass st=null since we don't need to undump any of the sub-elements
 	super(xa, ya, xb, yb, f, null, modelString, modelExternalNodes);
 	noDiagonal = true;
+	try {
+	    ctr = new Double(st.nextToken()).doubleValue();
+	} catch (Exception e) {
+	    ctr = 1.0;
+	}
 	initOptocoupler();
     }
 
     public String dump() {
-	return dumpWithMask(0);
+	return dumpWithMask(0) + " " + ctr;
     }
     
     private void initOptocoupler() {
@@ -36,7 +42,8 @@ public class OptocouplerElm extends CompositeElm {
 	CCCSElm cccs = (CCCSElm) compElmList.get(1);
 	
 	// from http://www.cel.com/pdf/appnotes/an3017.pdf
-	cccs.setExpr("max(0,min(.0001, select(i-.003, (-80000000000*(i)^5+800000000*(i)^4-3000000*(i)^3+5177.2*(i)^2+.2453*(i)-.00005)*1.04/700, (9000000*(i)^5-998113*(i)^4+42174*(i)^3-861.32*(i)^2+9.0836*(i)-.0078)*.945/700)))");
+	// the base expression models a ~100% CTR device; we scale by ctr
+	cccs.setExpr(ctr + "*max(0,min(.0001, select(i-.003, (-80000000000*(i)^5+800000000*(i)^4-3000000*(i)^3+5177.2*(i)^2+.2453*(i)-.00005)*1.04/700, (9000000*(i)^5-998113*(i)^4+42174*(i)^3-861.32*(i)^2+9.0836*(i)-.0078)*.945/700)))");
 	
 	transistor = (TransistorElm) compElmList.get(2);
 	transistor.setBeta(700);
@@ -177,11 +184,21 @@ public class OptocouplerElm extends CompositeElm {
 
     void getInfo(String arr[]) {
 	arr[0] = "optocoupler";
-	arr[1] = "Iin = " + getCurrentText(getCurrentIntoNode(0));
-	arr[2] = "Iout = " + getCurrentText(getCurrentIntoNode(2));
+	arr[1] = "CTR = " + (int)(ctr*100) + "%";
+	arr[2] = "Iin = " + getCurrentText(getCurrentIntoNode(0));
+	arr[3] = "Iout = " + getCurrentText(getCurrentIntoNode(2));
     }
 
     public EditInfo getEditInfo(int n) {
-        return null;
+	if (n == 0)
+	    return new EditInfo("CTR (%)", ctr * 100, 0, 0).setDimensionless();
+	return null;
+    }
+
+    public void setEditValue(int n, EditInfo ei) {
+	if (n == 0 && ei.value > 0) {
+	    ctr = ei.value / 100;
+	    initOptocoupler();
+	}
     }
 }

--- a/src/com/lushprojects/circuitjs1/client/SRAMElm.java
+++ b/src/com/lushprojects/circuitjs1/client/SRAMElm.java
@@ -32,10 +32,12 @@ import com.google.gwt.xml.client.Element;
 	int addressBits, dataBits;
 	HashMap<Integer, Integer> map;
 	HashMap<Integer, Integer> initialMap; // saved initial contents for restore on reset
+	String loadedFileName; // remembers the last file loaded via "Load Contents From File"
 	static final int FLAG_RELOAD_ON_RESET = 2;
 	static String contentsOverride = null;
 	TextArea editTextArea;
 	boolean hexTogglePending;
+	static String fileNameOverride = null;
 
 	public SRAMElm(int xx, int yy) {
 	    super(xx, yy);
@@ -139,6 +141,9 @@ import com.google.gwt.xml.client.Element;
         	ei.textArea.setVisibleLines(5);
         	String s = (contentsOverride != null) ? contentsOverride : contentsToString();
         	contentsOverride = null;
+		if (fileNameOverride != null)
+		    loadedFileName = fileNameOverride;
+		fileNameOverride = null;
     	    	ei.textArea.setText(s);
     	    	return ei;
             }
@@ -148,7 +153,9 @@ import com.google.gwt.xml.client.Element;
             	return ei;
             }
             if (n == 4 && SRAMLoadFile.isSupported()) {
-            	EditInfo ei = new EditInfo("", 0, -1, -1);
+            	EditInfo ei = new EditInfo(
+		    loadedFileName != null ? "Loaded: " + loadedFileName : "",
+		    0, -1, -1);
             	ei.loadFile = new SRAMLoadFile();
             	ei.button = new Button("Load Contents From File");
             	ei.newDialog = true;

--- a/src/com/lushprojects/circuitjs1/client/SRAMElm.java
+++ b/src/com/lushprojects/circuitjs1/client/SRAMElm.java
@@ -31,6 +31,8 @@ import com.google.gwt.xml.client.Element;
 	int addressNodes, dataNodes, internalNodes;
 	int addressBits, dataBits;
 	HashMap<Integer, Integer> map;
+	HashMap<Integer, Integer> initialMap; // saved initial contents for restore on reset
+	static final int FLAG_RELOAD_ON_RESET = 2;
 	static String contentsOverride = null;
 	TextArea editTextArea;
 	boolean hexTogglePending;
@@ -66,6 +68,8 @@ import com.google.gwt.xml.client.Element;
 		    }
 		}
 	    } catch (Exception e) {}
+	    if ((flags & FLAG_RELOAD_ON_RESET) != 0)
+		initialMap = new HashMap<Integer, Integer>(map);
 	}
 
 	void dumpXml(Document doc, Element elem) {
@@ -87,6 +91,12 @@ import com.google.gwt.xml.client.Element;
 		parseContentsString(xml.parseContents());
 	    } catch (Exception e) {}
 	    setupPins();
+	}
+
+	void reset() {
+	    super.reset();
+	    if ((flags & FLAG_RELOAD_ON_RESET) != 0 && initialMap != null)
+		map = new HashMap<Integer, Integer>(initialMap);
 	}
 
 	boolean nonLinear() { return true; }
@@ -144,6 +154,13 @@ import com.google.gwt.xml.client.Element;
             	ei.newDialog = true;
             	return ei;
             }
+	    int reloadIdx = SRAMLoadFile.isSupported() ? 5 : 4;
+	    if (n == reloadIdx) {
+		EditInfo ei = new EditInfo("", 0, -1, -1);
+		ei.checkbox = new Checkbox("Restore Contents on Reset",
+		    (flags & FLAG_RELOAD_ON_RESET) != 0);
+		return ei;
+	    }
 	    return super.getChipEditInfo(n);
 	}
 	
@@ -218,6 +235,8 @@ import com.google.gwt.xml.client.Element;
 		// skip re-parse during apply() if hex toggle already handled it
 		if (!hexTogglePending)
 		    parseContentsString(ei.textArea.getText());
+		if ((flags & FLAG_RELOAD_ON_RESET) != 0)
+		    initialMap = new HashMap<Integer, Integer>(map);
 	    }
 	    if (n == 3) {
 		if (hexTogglePending) {
@@ -238,6 +257,14 @@ import com.google.gwt.xml.client.Element;
 		    hexTogglePending = true;
 		    ei.newDialog = true;
 		}
+	    }
+	    int reloadIdx = SRAMLoadFile.isSupported() ? 5 : 4;
+	    if (n == reloadIdx) {
+		flags = ei.changeFlag(flags, FLAG_RELOAD_ON_RESET);
+		if ((flags & FLAG_RELOAD_ON_RESET) != 0)
+		    initialMap = new HashMap<Integer, Integer>(map);
+		else
+		    initialMap = null;
 	    }
 	}
 	int getVoltageSourceCount() { return dataBits; }

--- a/src/com/lushprojects/circuitjs1/client/SRAMLoadFile.java
+++ b/src/com/lushprojects/circuitjs1/client/SRAMLoadFile.java
@@ -30,23 +30,26 @@ public class SRAMLoadFile extends EditDialogLoadFile {
 				@com.lushprojects.circuitjs1.client.EditDialogLoadFile::doErrorCallback(Ljava/lang/String;)("Cannot load: That file is too large!");
 				return;
 			}
-			
+
+			var fileName = oFiles[0].name;
 			var reader = new FileReader();
 			reader.onload = function(e) {
 				var arr = new Uint8Array(reader.result);
 				var str = "0:";
 				for (var i = 0; i < arr.length; i++)
 					str += " " + arr[i];
-				@com.lushprojects.circuitjs1.client.SRAMLoadFile::doLoadCallback(Ljava/lang/String;)(str);
+				@com.lushprojects.circuitjs1.client.SRAMLoadFile::doLoadCallback(Ljava/lang/String;Ljava/lang/String;)(str, fileName);
 			};
-	
+
 			reader.readAsArrayBuffer(oFiles[0]);
 		}
 	}-*/;
-	
-	static public void doLoadCallback(String data) {
+
+	static public void doLoadCallback(String data, String fileName) {
 		SRAMElm.contentsOverride = data;
+		SRAMElm.fileNameOverride = fileName;
 		CirSim.editDialog.resetDialog();
 		SRAMElm.contentsOverride = null;
+		SRAMElm.fileNameOverride = null;
 	}
 }


### PR DESCRIPTION
## Summary
Rebased onto `v3-dev` (replaces #223 which targeted master).

- Adds adjustable CTR (current transfer ratio) for OptocouplerElm
- Adds "Restore Contents on Reset" option for SRAMElm (snapshots initial state)
- Adds voltage-limited current source (FLAG_VOLTAGE_LIMIT on CurrentElm)
- Fixes macOS Cmd+V paste in Electron app

Fixes #150, #184, #149, #138.

## Changes from master version
- Extended v3-dev's `dumpXml()`/`undumpXml()` in CurrentElm and SRAMElm to serialize new fields
- SRAMElm integrated with v3-dev's `parseContentsString()` helper

## Test plan
- [ ] Place Optocoupler → edit → verify CTR adjustment works
- [ ] Place SRAM → load data → enable Restore on Reset → reset → verify data restored
- [ ] Place current source → enable voltage limiting → verify current reduces at voltage limit
- [ ] In Electron on macOS → Cmd+V → verify paste works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
