### PR TITLE
Require sustained coil current before relay switches

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/RelayElm.java
+++ b/src/com/lushprojects/circuitjs1/client/RelayElm.java
@@ -64,6 +64,9 @@ class RelayElm extends CircuitElm {
     int poleCount;
     int openhs, dflip;
     boolean onState;
+
+    // track time current has been above/below threshold to filter transients
+    double onThresholdTime, offThresholdTime;
     final int nSwitch0 = 0;
     final int nSwitch1 = 1;
     final int nSwitch2 = 2;
@@ -328,6 +331,7 @@ class RelayElm extends CircuitElm {
 	for (i = 0; i != poleCount; i++)
 	    switchCurrent[i] = switchCurCount[i] = 0;
 	d_position = i_position = 0;
+	onThresholdTime = offThresholdTime = 0;
 
 	// preserve onState because if we don't, Relay Flip-Flop gets left in a weird state on reset.
 	// onState = false;
@@ -361,14 +365,23 @@ class RelayElm extends CircuitElm {
 	}
 	ind.startIteration(volts[nCoil1]-volts[nCoil3]);
 	double absCurrent = Math.abs(coilCurrent);
-	
+
+	// require current to be sustained above/below threshold for a minimum
+	// time before switching, to filter brief transients like back-EMF spikes
+	double minHoldTime = switchingTime * 0.5;
+
 	if (onState) {
 	    // on or turning on.  check if we need to turn off
 	    if (absCurrent < offCurrent) {
-		// turning off, set switch to intermediate position
-		onState = false;
-		i_position = 2;
+		offThresholdTime += sim.timeStep;
+		onThresholdTime = 0;
+		if (offThresholdTime >= minHoldTime) {
+		    // turning off, set switch to intermediate position
+		    onState = false;
+		    i_position = 2;
+		}
 	    } else {
+		offThresholdTime = 0;
 		d_position += sim.timeStep/switchingTime;
 		if (d_position >= 1)
 		    d_position = i_position = 1;
@@ -376,15 +389,20 @@ class RelayElm extends CircuitElm {
 	} else {
 	    // off or turning off.  check if we need to turn on
 	    if (absCurrent > onCurrent) {
-		// turning on, set switch to intermediate position
-		onState = true;
-		i_position = 2;
+		onThresholdTime += sim.timeStep;
+		offThresholdTime = 0;
+		if (onThresholdTime >= minHoldTime) {
+		    // turning on, set switch to intermediate position
+		    onState = true;
+		    i_position = 2;
+		}
 	    } else {
+		onThresholdTime = 0;
 		d_position -= sim.timeStep/switchingTime;
 		if (d_position <= 0)
 		    d_position = i_position = 0;
 	    }
-	    
+
 	}
     }
     


### PR DESCRIPTION
## Summary
- Fixes relay incorrectly switching due to brief back-EMF transients (#67)
- Adds threshold timers that require coil current to be sustained above/below the switching threshold for at least 50% of the switching time before the relay changes state
- Only affects the new relay model (switchingTime > 0); old model unchanged
- Threshold timers are cleared on reset

## Test plan
- [ ] Place a relay with the new model (default) and verify normal switching works
- [ ] Verify brief current spikes (e.g., from back-EMF) don't trigger false switching
- [ ] Test with different switching time values
- [ ] Verify old model relays (switchingTime = 0) are unaffected
- [ ] Reset circuit → verify relay resets cleanly

Fixes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)
