### PR TITLE
Fix analog-switch-induced spikes on comparator outputs

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/AnalogSwitchElm.java
+++ b/src/com/lushprojects/circuitjs1/client/AnalogSwitchElm.java
@@ -150,9 +150,12 @@ class AnalogSwitchElm extends CircuitElm {
 	}
     }
     void doStep() {
+	boolean wasOpen = open;
 	open = (volts[2] < threshold);
 	if (hasFlag(FLAG_INVERT))
 	    open = !open;
+	if (open != wasOpen)
+	    sim.converged = false;
 
 	// if pulldown flag is set, resistance is r_on.  Otherwise, no connection.
 	// if pulldown flag is unset, resistance is r_on for on, r_off for off.


### PR DESCRIPTION
## Summary

Fixes voltage spikes on comparator outputs that are caused by `AnalogSwitchElm` changing state mid-Newton-Raphson without forcing re-convergence.

**Note:** despite the original framing, this does **not** fix the specific buggy circuit in #90 (Paul confirmed there are no analog switches in that circuit, so this code path doesn't apply). It still fixes a real, distinct bug in any circuit where an analog switch is involved in a comparator's input or feedback path.

## Root cause

`AnalogSwitchElm.doStep()` was changing its switch state during Newton-Raphson sub-iterations without setting `sim.converged = false`. The new state would only be reflected in the next time step, so intermediate non-physical states could appear briefly on the output — visible as a spike on a comparator that shares the input.

## Fix

Track the previous switch state and set `sim.converged = false` when the switch changes state, forcing additional iterations until the circuit settles. This is the same pattern used by `OpAmpElm`, `TransistorElm`, `MosfetElm`, and `DiodeElm` for convergence checking. 3-line change in `AnalogSwitchElm.doStep()`.

## Test plan

- [ ] Comparator + analog switch in the input path: previously showed transient spikes synchronised with switch transitions; now clean.
- [ ] Stand-alone analog switch (no comparator): no regression in switching behavior.
- [ ] Multiple analog switches in a circuit: still converges.
- [ ] Comparator without an analog switch in any signal path: behavior unchanged (this PR doesn't touch comparator code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
