### PR TITLE
Improve op amp convergence for differentiator circuits

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/OpAmpElm.java
+++ b/src/com/lushprojects/circuitjs1/client/OpAmpElm.java
@@ -165,18 +165,29 @@ import com.google.gwt.xml.client.Document;
 	void doStep() {
 	    double vd = volts[1] - volts[0];
 	    double midpoint = (maxOut+minOut)*.5;
-	    if (Math.abs(lastvd-vd) > .1)
+	    double maxAdj = maxOut-midpoint;
+	    double minAdj = minOut-midpoint;
+
+	    // limit voltage change to prevent Newton-Raphson overshoot
+	    // in high-gain circuits (e.g., differentiators with fast edges)
+	    double maxVdStep = Math.abs(maxAdj/gain) * 100;
+	    if (maxVdStep < .1) maxVdStep = .1;
+	    if (Math.abs(vd - lastvd) > maxVdStep) {
+		vd = lastvd + Math.signum(vd - lastvd) * maxVdStep;
+		sim.converged = false;
+	    } else if (Math.abs(lastvd-vd) > .1)
 		sim.converged = false;
 	    else if (volts[2] > maxOut+.1 || volts[2] < minOut-.1)
 		sim.converged = false;
 	    double x = 0;
 	    double dx = 0;
-	    double maxAdj = maxOut-midpoint;
-	    double minAdj = minOut-midpoint;
-	    if (vd >= maxAdj/gain && (lastvd >= 0 || app.getrand(4) == 1)) {
+	    // use deterministic check instead of random getrand(4) to avoid
+	    // nondeterministic oscillation between saturation states
+	    boolean allowSwitch = (sim.subIterations > 20);
+	    if (vd >= maxAdj/gain && (lastvd >= 0 || allowSwitch)) {
 		dx = 1e-4;
 		x = maxOut - dx*maxAdj/gain;
-	    } else if (vd <= minAdj/gain && (lastvd <= 0 || app.getrand(4) == 1)) {
+	    } else if (vd <= minAdj/gain && (lastvd <= 0 || allowSwitch)) {
 		dx = 1e-4;
 		x = minOut - dx*minAdj/gain;
 	    } else {


### PR DESCRIPTION
## Summary
- Fixes ideal op amp "freaking out" in differentiator circuits with fast edges (#82)
- Two changes to `OpAmpElm.doStep()`:
  1. **Voltage limiting**: clamps differential input voltage change between iterations to prevent Newton-Raphson overshoot. With gain=100000, the linear region is only ~0.3mV wide — without limiting, the iteration bounces wildly between saturation states.
  2. **Deterministic convergence escape**: replaces the random `getrand(4)==1` check with a deterministic `subIterations > 20` condition. The random 25% chance of switching saturation direction introduced nondeterministic oscillation that destabilized converging iterations in high-gain circuits.

## Test plan
- [ ] Build op amp differentiator with 1k resistor + capacitor + logic input pulse → verify stable output
- [ ] Verify the built-in differentiator example (amp-dfdx.txt) still works correctly
- [ ] Test Schmitt trigger circuit (amp-schmitt.txt) → verify hysteresis still works
- [ ] Test standard op amp circuits (inverting, non-inverting, integrator) for regression
- [ ] Verify lower-gain op amps are unaffected

Fixes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)
