### PR TITLE
Add gmin stepping to VCCS/CCCS for convergence aid

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/CCCSElm.java
+++ b/src/com/lushprojects/circuitjs1/client/CCCSElm.java
@@ -141,6 +141,14 @@ class CCCSElm extends VCCSElm {
         	sim.stampCurrentSource(nodes[inputCount+1], nodes[inputCount], rs);
             }
 
+            // add gmin stepping to aid convergence, same as VCCSElm
+            if (sim.subIterations > 100) {
+        	double gmin = Math.exp(-9*Math.log(10)*(1-sim.subIterations/3000.));
+        	if (gmin > .1)
+        	    gmin = .1;
+        	sim.stampResistor(nodes[inputCount], nodes[inputCount+1], 1.0/gmin);
+            }
+
             for (i = 0; i != inputPairCount; i++)
                 lastCurrents[i] = pins[i*2+1].current;
         }

--- a/src/com/lushprojects/circuitjs1/client/VCCSElm.java
+++ b/src/com/lushprojects/circuitjs1/client/VCCSElm.java
@@ -159,6 +159,18 @@ class VCCSElm extends ChipElm {
         	pins[inputCount+1].current = v0;
             }
 
+            // add gmin stepping to aid convergence, similar to Diode and
+            // TransistorElm.  Without this, circuits with controlled sources
+            // in positive feedback loops (e.g., optocoupler Schmitt triggers)
+            // can fail to converge because the Newton-Raphson iteration
+            // oscillates between two states with no damping.
+            if (sim.subIterations > 100) {
+        	double gmin = Math.exp(-9*Math.log(10)*(1-sim.subIterations/3000.));
+        	if (gmin > .1)
+        	    gmin = .1;
+        	sim.stampResistor(nodes[inputCount], nodes[inputCount+1], 1.0/gmin);
+            }
+
             for (i = 0; i != inputCount; i++)
         	lastVolts[i] = volts[i];
         }


### PR DESCRIPTION
## Summary
- Fixes convergence failures in circuits with controlled sources in positive feedback loops (#172)
- Adds gmin stepping (parallel conductance that gradually increases with subiterations) to both VCCSElm and CCCSElm, following the same well-established pattern used by Diode.java and TransistorElm.java
- The optocoupler Schmitt trigger circuit in #172 fails because the CCCS inside the optocoupler oscillates between two states with no damping mechanism — the solver bounces back and forth for 5000 iterations then gives up
- Uses a slower ramp rate (subIterations/3000) compared to transistors (subIterations/300) to minimize impact on normally-converging circuits

## Test plan
- [ ] Build the optocoupler Schmitt trigger circuit from issue #172 → verify it converges
- [ ] Test standard VCCS and CCCS circuits → verify no regression
- [ ] Test optocoupler in normal (non-feedback) configuration → verify correct behavior
- [ ] Test circuits with multiple controlled sources → verify convergence

Fixes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)
