### PR TITLE
use lightGrayColor for OutputElm to distinguish from LabeledNodeElm

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/OutputElm.java
+++ b/src/com/lushprojects/circuitjs1/client/OutputElm.java
@@ -66,7 +66,7 @@ class OutputElm extends CircuitElm {
 	    boolean selected = needsHighlight();
 	    Font f = new Font("SansSerif", selected ? Font.BOLD : 0, 14);
 	    g.setFont(f);
-	    g.setColor(selected ? selectColor : whiteColor);
+	    g.setColor(selected ? selectColor : lightGrayColor);
 	    String s = showVoltage() ? getUnitTextWithScale(volts[0], "V", scale, isFixed()) : Locale.LS("out");
 //	    FontMetrics fm = g.getFontMetrics();
 	    if (this == app.mouse.plotXElm)


### PR DESCRIPTION
## Summary
- Changes OutputElm text color from `whiteColor` to `lightGrayColor` so users can visually distinguish output probes from labeled nodes at a glance

Fixes #87

## Test plan
- [ ] Place an OutputElm and a LabeledNodeElm on the canvas
- [ ] Verify OutputElm text appears in light gray while LabeledNodeElm remains white
- [ ] Verify selected state still uses selectColor for both

🤖 Generated with [Claude Code](https://claude.com/claude-code)
