### PR TITLE
add .editorconfig for consistent coding style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+# EditorConfig helps maintain consistent coding styles across editors
+# https://editorconfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.java]
+indent_style = tab
+indent_size = 8
+
+[*.html]
+indent_style = space
+indent_size = 2
+
+[*.txt]
+trim_trailing_whitespace = false
+
+[*.{gradle,xml}]
+indent_style = space
+indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -11,7 +11,8 @@ insert_final_newline = true
 
 [*.java]
 indent_style = tab
-indent_size = 8
+indent_size = 4
+tab_width = 8
 
 [*.html]
 indent_style = space


### PR DESCRIPTION
## Summary
- Adds `.editorconfig` file matching existing codebase conventions: tabs for Java, spaces for HTML/Gradle/XML
- Helps contributors use correct indentation without manual configuration

Fixes #35

## Test plan
- [ ] Open the project in an EditorConfig-aware editor (VS Code, IntelliJ, etc.)
- [ ] Verify Java files use tab indentation
- [ ] Verify HTML files use 2-space indentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
