### PR TITLE
add CSV export to oscilloscope context menu

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/CommandManager.java
+++ b/src/com/lushprojects/circuitjs1/client/CommandManager.java
@@ -253,6 +253,8 @@ public class CommandManager {
     			s.selectY();
     		if (item=="reset")
     			s.resetGraph(true);
+    		if (item=="exportcsv")
+    			s.exportCSV();
     		if (item=="properties")
 			s.properties();
     		app.scopeManager.deleteUnusedScopeElms();

--- a/src/com/lushprojects/circuitjs1/client/Scope.java
+++ b/src/com/lushprojects/circuitjs1/client/Scope.java
@@ -1758,7 +1758,54 @@ class Scope {
 	properties = new ScopePropertiesDialog(app, this);
 	CirSim.dialogShowing = properties;
     }
-    
+
+    void exportCSV() {
+	if (visiblePlots.size() == 0)
+	    return;
+	StringBuilder sb = new StringBuilder();
+	sb.append("time");
+	int i;
+	for (i = 0; i != visiblePlots.size(); i++) {
+	    ScopePlot plot = visiblePlots.get(i);
+	    String name = plot.elm.getClass().getSimpleName().replace("Elm", "");
+	    String unit = getScaleUnitsText(plot.units);
+	    sb.append(",\"" + name + " " + unit + " min\"");
+	    sb.append(",\"" + name + " " + unit + " max\"");
+	}
+	sb.append("\n");
+	// all visible plots share the same scopePointCount and speed
+	ScopePlot plot0 = visiblePlots.get(0);
+	int w = rect.width;
+	double ts = sim.maxTimeStep * speed;
+	double tStart = sim.t - ts * w;
+	int ipa = plot0.startIndex(w);
+	for (i = 0; i != w; i++) {
+	    double t = tStart + ts * i;
+	    sb.append(t);
+	    int j;
+	    for (j = 0; j != visiblePlots.size(); j++) {
+		ScopePlot plot = visiblePlots.get(j);
+		int ip = (i + plot.startIndex(w)) & (plot.scopePointCount - 1);
+		sb.append("," + plot.minValues[ip]);
+		sb.append("," + plot.maxValues[ip]);
+	    }
+	    sb.append("\n");
+	}
+	downloadCSV(sb.toString(), "scope-data.csv");
+    }
+
+    static native void downloadCSV(String data, String filename) /*-{
+	var blob = new Blob([data], {type: 'text/csv'});
+	var url = URL.createObjectURL(blob);
+	var a = $doc.createElement('a');
+	a.href = url;
+	a.download = filename;
+	$doc.body.appendChild(a);
+	a.click();
+	$doc.body.removeChild(a);
+	URL.revokeObjectURL(url);
+    }-*/;
+
     void speedUp() {
 	if (speed > 1) {
 	    speed /= 2;

--- a/src/com/lushprojects/circuitjs1/client/ScopePopupMenu.java
+++ b/src/com/lushprojects/circuitjs1/client/ScopePopupMenu.java
@@ -48,6 +48,7 @@ public class ScopePopupMenu {
 	 m.addItem(combineItem = new CheckboxAlignedMenuItem(Locale.LS("Combine"), new MyCommand("scopepop", "combine")));
 	 m.addItem(removePlotItem = new CheckboxAlignedMenuItem(Locale.LS("Remove Plot"),new MyCommand("scopepop", "removeplot")));
 	 m.addItem(resetItem = new CheckboxAlignedMenuItem(Locale.LS("Reset"), new MyCommand("scopepop", "reset")));
+	 m.addItem(new CheckboxAlignedMenuItem(Locale.LS("Export CSV..."), new MyCommand("scopepop", "exportcsv")));
 	 m.addItem(propertiesItem = new CheckboxAlignedMenuItem(Locale.LS("Properties..."), new MyCommand("scopepop", "properties")));
     }
     


### PR DESCRIPTION
## Summary
- Adds "Export CSV..." option to the scope right-click context menu
- Downloads visible plot data as a CSV file with time, min, and max columns for each signal
- Uses JSNI Blob/anchor pattern consistent with existing export code (ExportAsLocalFileDialog, DataRecorderElm)

Fixes #173

## Test plan
- [ ] Create a circuit with a scope showing voltage and/or current
- [ ] Right-click scope and select "Export CSV..."
- [ ] Verify a CSV file downloads with correct time column and min/max data for each visible plot
- [ ] Open CSV in a spreadsheet and verify data matches scope display
- [ ] Test with multiple combined plots on a single scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)
