### PR TITLE
use smooth abs() approximation for Newton-Raphson convergence

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/Expr.java
+++ b/src/com/lushprojects/circuitjs1/client/Expr.java
@@ -73,7 +73,7 @@ class Expr {
 	case E_T: return es.t;
 	case E_SIN: return Math.sin(left.eval(es));
 	case E_COS: return Math.cos(left.eval(es));
-	case E_ABS: return Math.abs(left.eval(es));
+	case E_ABS: { double x = left.eval(es); return Math.sqrt(x*x + 1e-18); }
 	case E_EXP: return Math.exp(left.eval(es));
 	case E_LOG: return Math.log(left.eval(es));
 	case E_SQRT: return Math.sqrt(left.eval(es));


### PR DESCRIPTION
## Summary
- Replaces `Math.abs(x)` with `Math.sqrt(x*x + 1e-18)` in the expression evaluator
- `abs()` is non-differentiable at zero, causing Newton-Raphson convergence failure when used in VCCS/CCVS expressions like `abs(dadt)`
- The smooth approximation only differs from true `abs()` by ~1e-9 near zero

Fixes #43

## Test plan
- [ ] Create a VCCS with expression `abs(a-b)` and verify it converges
- [ ] Create a CCVS with expression `abs(dadt)` and verify it converges (the original bug)
- [ ] Verify existing circuits using abs() still work correctly
- [ ] Load the op-amp chaotic circuits (Rossler, Chua) which may use abs()

🤖 Generated with [Claude Code](https://claude.com/claude-code)
