### PR TITLE
add GitHub Actions CI workflow for build verification

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: Build
+
+on:
+  push:
+    branches: [ master, v3-dev ]
+  pull_request:
+    branches: [ master, v3-dev ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v4
+
+    - name: Build with Gradle
+      run: gradle compileGwt --console verbose
+
+    - name: Build site
+      run: gradle makeSite --console verbose


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions CI workflow that builds the project on every push/PR to `master` and `v3-dev`
- Uses JDK 17 (temurin), `gradle/actions/setup-gradle@v4`, runs `compileGwt` then `makeSite`
- Provides basic build verification to catch compilation errors early

## Test plan
- [ ] Verify workflow triggers on push to master and v3-dev
- [ ] Verify workflow triggers on PRs targeting master and v3-dev
- [ ] Confirm `compileGwt` step succeeds
- [ ] Confirm `makeSite` step succeeds

Fixes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)
