### PR TITLE
fix labeled node truncation in subcircuit creation

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/EditCompositeModelDialog.java
+++ b/src/com/lushprojects/circuitjs1/client/EditCompositeModelDialog.java
@@ -84,10 +84,6 @@ public class EditCompositeModelDialog extends Dialog implements MouseDownHandler
         	ExtListEntry pin = model.extList.get(i);
                 sideCounts[pin.side] += 1;
 
-        	if (nodeSet.contains(pin.node)) {
-        	    Window.alert(Locale.LS("Can't have two input/output nodes connected!"));
-        	    return false;
-        	}
         	nodeSet.add(pin.node);
             }
 

--- a/src/com/lushprojects/circuitjs1/client/SimulationManager.java
+++ b/src/com/lushprojects/circuitjs1/client/SimulationManager.java
@@ -2,6 +2,7 @@ package com.lushprojects.circuitjs1.client;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Vector;
 
@@ -1403,9 +1404,10 @@ public class SimulationManager {
         };
 	Vector<ExtListEntry> extList = new Vector<ExtListEntry>();
 	boolean sel = app.isSelection();
-	    
+
 	boolean used[] = new boolean[nodeList.size()];
 	boolean extnodes[] = new boolean[nodeList.size()];
+	HashSet<String> seenLabels = new HashSet<String>();
 	    
 	// redo node allocation to avoid auto-assigning ground
 	if (!preStampCircuit(true))
@@ -1422,9 +1424,11 @@ public class SimulationManager {
 		if (lne.isInternal())
 		    continue;
 		
-		// already added to list?
-		if (extnodes[ce.getNode(0)])
+		// already added to list? (deduplicate by label text, not node number,
+		// so that different labels on the same node each get their own pin)
+		if (seenLabels.contains(label))
 		    continue;
+		seenLabels.add(label);
 		
 	    int side = ChipElm.SIDE_W;
 	    if (Math.abs(ce.dx) >= Math.abs(ce.dy) && ce.dx > 0) side = ChipElm.SIDE_E;


### PR DESCRIPTION
## Summary
- Fixes labeled node truncation when creating subcircuits: different-named labels on the same electrical node now each get their own pin
- Changed deduplication in `getCircuitAsComposite()` from node-number-based to label-text-based, so e.g. "GND_FIRST" and "GND_NEXT" both appear as pins even if they share an internal node
- Removed the "Can't have two input/output nodes connected" validation that blocked model creation when multiple pins map to the same internal node (mirrors real ICs with multiple GND/VCC pins)

## Test plan
- [ ] Create a circuit with two LabeledNodeElm elements with different names connected to the same node
- [ ] Use "Save as Subcircuit" — both labels should appear as pins on the subcircuit chip
- [ ] Verify existing subcircuits with unique nodes per label still work correctly
- [ ] Verify backward compatibility with saved subcircuit models

Fixes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)
