### PR TITLE
add configurable high logic voltage for subcircuits

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/ChipElm.java
+++ b/src/com/lushprojects/circuitjs1/client/ChipElm.java
@@ -260,6 +260,8 @@ abstract class ChipElm extends CircuitElm {
 	    }
 	    System.out.println("setVoltageSource failed for " + this);
 	}
+	void setHighVoltage(double hv) { highVoltage = hv; }
+
 	void stamp() {
 	    int i;
 	    int vsc = 0;

--- a/src/com/lushprojects/circuitjs1/client/CircuitElm.java
+++ b/src/com/lushprojects/circuitjs1/client/CircuitElm.java
@@ -245,8 +245,11 @@ public abstract class CircuitElm implements Editable {
 	curcount = 0;
     }
     void draw(Graphics g) {}
-    
-    // set current for voltage source vn to c.  vn will be the same value as in a previous call to setVoltageSource(n, vn) 
+
+    // override this in elements that use highVoltage (gates, chips, inverters, etc.)
+    void setHighVoltage(double hv) {}
+
+    // set current for voltage source vn to c.  vn will be the same value as in a previous call to setVoltageSource(n, vn)
     void setCurrent(int vn, double c) { current = c; }
     
     // get current for one- or two-terminal elements

--- a/src/com/lushprojects/circuitjs1/client/CustomCompositeElm.java
+++ b/src/com/lushprojects/circuitjs1/client/CustomCompositeElm.java
@@ -16,6 +16,7 @@ public class CustomCompositeElm extends CompositeElm {
     int postCount;
     int inputCount, outputCount;
     CustomCompositeModel model;
+    double highVoltage;
     static String lastModelName = "default";
     static final int FLAG_SMALL = 2;
     
@@ -60,10 +61,13 @@ public class CustomCompositeElm extends CompositeElm {
 	dumpXmlModel(doc);
 	super.dumpXml(doc, elem);
 	XMLSerializer.dumpAttr(elem, "mo", modelName);
+	if (highVoltage != 0)
+	    XMLSerializer.dumpAttr(elem, "hv", highVoltage);
     }
 
     void undumpXml(XMLDeserializer xml) {
 	modelName = xml.parseStringAttr("mo", modelName);
+	highVoltage = xml.parseDoubleAttr("hv", 0);
 	updateModels();
 	super.undumpXml(xml);
     }
@@ -163,10 +167,22 @@ public class CustomCompositeElm extends CompositeElm {
 	} else {
 	    loadCompositeXml(model.getElmEntries(), externalNodes);
 	}
+	propagateHighVoltage();
 	allocNodes();
 	setPoints();
     }
     
+    void propagateHighVoltage() {
+	if (highVoltage == 0)
+	    return;
+	for (int i = 0; i != compElmList.size(); i++) {
+	    CircuitElm ce = compElmList.get(i);
+	    ce.setHighVoltage(highVoltage);
+	    if (ce instanceof CustomCompositeElm)
+		((CustomCompositeElm) ce).propagateHighVoltage();
+	}
+    }
+
     int getPostCount() { return postCount; }
     
     Vector<CustomCompositeModel> models;
@@ -199,8 +215,10 @@ public class CustomCompositeElm extends CompositeElm {
             ei.button = new Button(Locale.LS("View Components"));
             return ei;
         }
-	int loadModelCircuit = (canViewComponents()) ? 3 : 2;
-        if (n == loadModelCircuit && model.canLoadModelCircuit()) {
+	int hvIdx = (canViewComponents()) ? 3 : 2;
+        if (n == hvIdx)
+            return new EditInfo("High Logic Voltage (0=default)", highVoltage, 0, 10);
+        if (n == hvIdx+1 && model.canLoadModelCircuit()) {
             EditInfo ei = new EditInfo("", 0, -1, -1);
             ei.button = new Button(Locale.LS("Edit Model"));
             return ei;
@@ -234,8 +252,12 @@ public class CustomCompositeElm extends CompositeElm {
             app.ui.pushSubcircuit(this, buildDisplayElmList());
             CirSim.editDialog.closeDialog();
         }
-	int loadModelCircuit = (canViewComponents()) ? 3 : 2;
-        if (n == loadModelCircuit) {
+	int hvIdx = (canViewComponents()) ? 3 : 2;
+        if (n == hvIdx) {
+            highVoltage = ei.value;
+            propagateHighVoltage();
+        }
+        if (n == hvIdx+1) {
             app.pushContext(model.name);
             if (model.modelCircuit != null)
         	app.readCircuit(model.modelCircuit);

--- a/src/com/lushprojects/circuitjs1/client/DelayBufferElm.java
+++ b/src/com/lushprojects/circuitjs1/client/DelayBufferElm.java
@@ -58,7 +58,8 @@ class DelayBufferElm extends CircuitElm {
 	}
 
 	int getDumpType() { return 422; }
-	
+	void setHighVoltage(double hv) { highVoltage = hv; }
+
 	Point center;
 	
 	void draw(Graphics g) {

--- a/src/com/lushprojects/circuitjs1/client/GateElm.java
+++ b/src/com/lushprojects/circuitjs1/client/GateElm.java
@@ -211,6 +211,8 @@ abstract class GateElm extends CircuitElm {
 	    arr[1] = "Vout = " + getVoltageText(volts[inputCount]);
 	    arr[2] = "Iout = " + getCurrentText(getCurrent());
 	}
+	void setHighVoltage(double hv) { highVoltage = hv; }
+
 	void stamp() {
 	    sim.stampVoltageSource(0, nodes[inputCount], voltSource);
 	}

--- a/src/com/lushprojects/circuitjs1/client/InverterElm.java
+++ b/src/com/lushprojects/circuitjs1/client/InverterElm.java
@@ -104,6 +104,7 @@ class InverterElm extends CircuitElm {
 	    setBbox(point1, point2, hs);
 	}
 	int getVoltageSourceCount() { return 1; }
+	void setHighVoltage(double hv) { highVoltage = hv; }
 	void stamp() {
 	    sim.stampVoltageSource(0, nodes[1], voltSource);
 	}

--- a/src/com/lushprojects/circuitjs1/client/TriStateElm.java
+++ b/src/com/lushprojects/circuitjs1/client/TriStateElm.java
@@ -86,6 +86,7 @@ class TriStateElm extends CircuitElm {
 
     int getDumpType() { return 180; }
     String getXmlDumpType() { return "ts"; }
+    void setHighVoltage(double hv) { highVoltage = hv; }
 
     boolean open;
 

--- a/src/com/lushprojects/circuitjs1/public/circuits/subcircuit-highvoltage-nested.txt
+++ b/src/com/lushprojects/circuitjs1/public/circuits/subcircuit-highvoltage-nested.txt
@@ -1,0 +1,18 @@
+<cir f="4" ts="5.0E-6" ic="4.7619476E-13" cb="50" pb="50" vr="5.0" mts="5.0E-11">
+  <ccm nm="hv-buf-inner" f="0" sx="1" sy="1">
+    <ext nm="in" nd="1" ps="0" sd="0"/>
+    <ext nm="out" nd="3" ps="0" sd="2"/>
+    <I nn="1 2" sl="0.5" hi="5.0"/>
+    <I nn="2 3" sl="0.5" hi="5.0"/>
+  </ccm>
+  <ccm nm="hv-buf-outer" f="0" sx="1" sy="1">
+    <ext nm="in" nd="1" ps="0" sd="0"/>
+    <ext nm="out" nd="2" ps="0" sd="2"/>
+    <cc nn="1 2" mo="hv-buf-inner"/>
+  </ccm>
+  <L x="208 192 272 192" hi="3.3"/>
+  <cc x="336 192 400 192" mo="hv-buf-outer" hv="3.3"/>
+  <M x="464 192 528 192" th="1.65"/>
+  <w x="272 192 336 192"/>
+  <w x="400 192 464 192"/>
+</cir>


### PR DESCRIPTION
## Summary
- Adds a "High Logic Voltage" parameter to subcircuit instances (`CustomCompositeElm`) that propagates to all internal digital elements
- Allows different instances of the same subcircuit model to operate at different voltage levels (e.g., 3.3V vs 5V) without needing separate models
- Adds `setHighVoltage()` virtual method to `CircuitElm`, overridden in `GateElm`, `ChipElm`, `InverterElm`, `TriStateElm`, and `DelayBufferElm`
- Setting 0 (default) preserves each element's original voltage — fully backward compatible
- Propagation recurses into nested subcircuits
- Value serialized as `hv` XML attribute (only when non-zero)

## Test plan
- [ ] Create a subcircuit containing logic gates (AND, OR, inverter, etc.)
- [ ] Edit the subcircuit instance and set "High Logic Voltage" to 3.3
- [ ] Verify internal gates output 3.3V instead of 5V
- [ ] Create two instances of the same model with different voltages — verify independent operation
- [ ] Save and reload — verify voltage setting persists
- [ ] Verify default (0) preserves original per-element voltage settings

Fixes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)
