### PR TITLE
filter by extension in open file dialog

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/AudioInputElm.java
+++ b/src/com/lushprojects/circuitjs1/client/AudioInputElm.java
@@ -154,6 +154,7 @@ class AudioInputElm extends RailElm {
                 EditInfo ei = new EditInfo("", 0, -1, -1);
                 final AudioInputElm thisElm = this;
                 final FileUpload file = new FileUpload();
+                file.getElement().setAttribute("accept", "audio/*");
                 ei.widget = file;
                 file.addChangeHandler(new ChangeHandler() {
 			    public void onChange(ChangeEvent event) {

--- a/src/com/lushprojects/circuitjs1/client/LoadFile.java
+++ b/src/com/lushprojects/circuitjs1/client/LoadFile.java
@@ -46,6 +46,7 @@ public class LoadFile extends FileUpload implements  ChangeHandler {
 		sim=s;
 		this.setName("Import");
 		this.getElement().setId("LoadFileElement");
+		this.getElement().setAttribute("accept", "text/plain");
 		this.addChangeHandler(this);
 		this.addStyleName("offScreen");
 	}


### PR DESCRIPTION
## Summary

Ports the `origin/filter-by-extension` branch to v3-dev. Adds HTML `accept` attributes to file upload elements so the OS file picker shows only relevant files by default:

- **Circuit file dialog** (`LoadFile.java`): filters to `text/plain`
- **Audio input element** (`AudioInputElm.java`): filters to `audio/*`

Users can still override the filter in their OS file dialog to see all files.

Originally from sharpie7/circuitjs1 issue #355.

## Test plan

- [ ] File > Open — verify file picker defaults to showing text files
- [ ] Edit an AudioInputElm — verify file picker defaults to showing audio files
- [ ] Verify both dialogs still allow selecting other file types via the OS filter override

🤖 Generated with [Claude Code](https://claude.com/claude-code)
