### PR TITLE
Fix compileGwt: move ElementFactoryGenerator to rebind package

### DIFF
--- a/src/com/lushprojects/circuitjs1/circuitjs1.gwt.xml
+++ b/src/com/lushprojects/circuitjs1/circuitjs1.gwt.xml
@@ -6,7 +6,7 @@
     <inherits name="com.google.gwt.xml.XML"/>
     <entry-point class="com.lushprojects.circuitjs1.client.circuitjs1" />
     <stylesheet src='style.css' />
-    <generate-with class="com.lushprojects.circuitjs1.client.generator.ElementFactoryGenerator">
+    <generate-with class="com.lushprojects.circuitjs1.rebind.ElementFactoryGenerator">
         <when-type-assignable class="com.lushprojects.circuitjs1.client.ElementFactory"/>
     </generate-with>
 </module>

--- a/src/com/lushprojects/circuitjs1/rebind/ElementFactoryGenerator.java
+++ b/src/com/lushprojects/circuitjs1/rebind/ElementFactoryGenerator.java
@@ -1,4 +1,4 @@
-package com.lushprojects.circuitjs1.client.generator;
+package com.lushprojects.circuitjs1.rebind;
 
 import com.google.gwt.core.ext.Generator;
 import com.google.gwt.core.ext.GeneratorContext;
@@ -21,7 +21,7 @@ public class ElementFactoryGenerator extends Generator {
 	// Iterate over all constructors
 	for (JConstructor constructor : constructors) {
 	    JParameter[] params = constructor.getParameters();
-	    
+
 	    // Check if the constructor has exactly two parameters
 	    if (params.length == 2) {
 		// Check if both parameters are of type int
@@ -41,7 +41,7 @@ public class ElementFactoryGenerator extends Generator {
 	// Iterate over all constructors
 	for (JConstructor constructor : constructors) {
 	    JParameter[] params = constructor.getParameters();
-	    
+
 	    if (params.length == 6) {
 		int i;
 		for (i = 0; i != 5; i++)


### PR DESCRIPTION
## Summary
- Move `ElementFactoryGenerator.java` from `client/generator/` to `rebind/` package
- Update `circuitjs1.gwt.xml` `<generate-with>` reference to match new location
- Fixes `gradle compileGwt` which was broken with 11 "No source code is available" errors

## Problem
GWT treats everything under the `client` package as translatable source (Java→JavaScript). `ElementFactoryGenerator` is a compile-time code generator that uses GWT infrastructure classes (`Generator`, `TreeLogger`, `TypeOracle`, `SourceWriter`, etc.) which only exist as JVM bytecode — not as GWT-translatable source. This caused `compileGwt` to fail with errors like:

```
No source code is available for type com.google.gwt.core.ext.Generator; did you forget to inherit a required module?
No source code is available for type com.google.gwt.core.ext.typeinfo.TypeOracle; did you forget to inherit a required module?
```

## Fix
Move the generator to `com.lushprojects.circuitjs1.rebind` — the standard GWT convention for compile-time generator classes (sibling to `client`, not inside it).

## Test plan
- [x] `gradle compileJava` passes
- [x] `gradle compileGwt` passes (previously failed)
- [x] `gradle makeSite` produces working site

🤖 Generated with [Claude Code](https://claude.com/claude-code)
