### PR TITLE
add BAT85 Schottky diode to built-in diode models

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/DiodeModel.java
+++ b/src/com/lushprojects/circuitjs1/client/DiodeModel.java
@@ -93,6 +93,9 @@ public class DiodeModel implements Editable, Comparable<DiodeModel> {
 	addDefaultModel("1N5711", new DiodeModel(315e-9, 2.8, 2.03, 70, "Schottky"));
 	addDefaultModel("1N5712", new DiodeModel(680e-12, 12, 1.003, 20, "Schottky"));
 
+	// https://github.com/peteut/spice-models/blob/master/nxp/sbd/sbd.txt
+	addDefaultModel("BAT85", new DiodeModel(2.076e-7, 2.326, 1.023, 33, "Schottky"));
+
 	// model is inaccurate
 	addDefaultModel("1N34", new DiodeModel(200e-12, 84e-3, 2.19, 60, "germanium").setInternal());
 


### PR DESCRIPTION
## Summary
- Adds the BAT85 Schottky barrier diode to the built-in diode model list
- Parameters sourced from NXP official SPICE model: IS=2.076e-7, RS=2.326, N=1.023, BV=33
- Placed alongside existing Schottky models (1N5711, 1N5712)

## BAT85 Specifications
| Parameter | Value | Description |
|-----------|-------|-------------|
| IS | 2.076e-7 A | Saturation current |
| RS | 2.326 ohm | Series resistance |
| N | 1.023 | Emission coefficient |
| BV | 33 V | Breakdown voltage |

The BAT85 is a widely-used Schottky barrier diode from Nexperia (formerly NXP), popular for signal detection, RF rectification, and free-wheeling applications due to its low forward voltage drop (~0.34V typical) and fast switching.

**SPICE model source:** https://github.com/peteut/spice-models/blob/master/nxp/sbd/sbd.txt

## Test plan
- [ ] Verify BAT85 appears in diode model dropdown when editing a diode
- [ ] Verify forward voltage behavior matches datasheet (~0.34V at low current)
- [ ] Verify reverse breakdown at ~33V
- [ ] Verify no regression in existing Schottky models (1N5711, 1N5712)
