### PR TITLE
fix square wave initial value with negative phase shift

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/VoltageElm.java
+++ b/src/com/lushprojects/circuitjs1/client/VoltageElm.java
@@ -150,22 +150,18 @@ class VoltageElm extends CircuitElm {
 	    return bias;
 	
 	double w = 2*pi*(sim.t-freqTimeZero)*frequency + phaseShift;
-	// Normalize phase to [0, 2pi) for waveforms that use modulo.
-	// Java's % on negative numbers returns negative results, which
-	// causes wrong output when phase shift is negative.
-	double wn = ((w % (2*pi)) + 2*pi) % (2*pi);
 	switch (waveform) {
 	case WF_DC: return maxVoltage+bias;
 	case WF_AC: return Math.sin(w)*maxVoltage+bias;
 	case WF_SQUARE:
-	    return bias+((wn > (2*pi*dutyCycle)) ?
+	    return bias+((w % (2*pi) > (2*pi*dutyCycle)) ?
 			 -maxVoltage : maxVoltage);
 	case WF_TRIANGLE:
-	    return bias+triangleFunc(wn)*maxVoltage;
+	    return bias+triangleFunc(w % (2*pi))*maxVoltage;
 	case WF_SAWTOOTH:
-	    return bias+wn*(maxVoltage/pi)-maxVoltage;
+	    return bias+(w % (2*pi))*(maxVoltage/pi)-maxVoltage;
 	case WF_PULSE:
-	    return (wn < (2*pi*dutyCycle)) ? maxVoltage+bias : bias;
+	    return ((w % (2*pi)) < (2*pi*dutyCycle)) ? maxVoltage+bias : bias;
 	case WF_NOISE:
 	    return noiseValue;
 	default: return 0;
@@ -463,8 +459,11 @@ class VoltageElm extends CircuitElm {
 
 	    setPoints();
 	}
-	if (n == fo+1)
+	if (n == fo+1) {
 	    phaseShift = ei.value*pi/180;
+	    // normalize to [0, 2*pi)
+	    phaseShift = ((phaseShift % (2*pi)) + 2*pi) % (2*pi);
+	}
 	if (n == fo+2)
 	    dutyCycle = ei.value*.01;
     }

--- a/src/com/lushprojects/circuitjs1/client/VoltageElm.java
+++ b/src/com/lushprojects/circuitjs1/client/VoltageElm.java
@@ -150,18 +150,22 @@ class VoltageElm extends CircuitElm {
 	    return bias;
 	
 	double w = 2*pi*(sim.t-freqTimeZero)*frequency + phaseShift;
+	// Normalize phase to [0, 2pi) for waveforms that use modulo.
+	// Java's % on negative numbers returns negative results, which
+	// causes wrong output when phase shift is negative.
+	double wn = ((w % (2*pi)) + 2*pi) % (2*pi);
 	switch (waveform) {
 	case WF_DC: return maxVoltage+bias;
 	case WF_AC: return Math.sin(w)*maxVoltage+bias;
 	case WF_SQUARE:
-	    return bias+((w % (2*pi) > (2*pi*dutyCycle)) ?
+	    return bias+((wn > (2*pi*dutyCycle)) ?
 			 -maxVoltage : maxVoltage);
 	case WF_TRIANGLE:
-	    return bias+triangleFunc(w % (2*pi))*maxVoltage;
+	    return bias+triangleFunc(wn)*maxVoltage;
 	case WF_SAWTOOTH:
-	    return bias+(w % (2*pi))*(maxVoltage/pi)-maxVoltage;
+	    return bias+wn*(maxVoltage/pi)-maxVoltage;
 	case WF_PULSE:
-	    return ((w % (2*pi)) < (2*pi*dutyCycle)) ? maxVoltage+bias : bias;
+	    return (wn < (2*pi*dutyCycle)) ? maxVoltage+bias : bias;
 	case WF_NOISE:
 	    return noiseValue;
 	default: return 0;


### PR DESCRIPTION
## Summary
- Normalizes the phase angle to [0, 2pi) before waveform threshold comparisons in VoltageElm.getVoltage()
- Java modulo on negative numbers returns negative results, causing wrong initial output when phase shift is negative
- Fixes square wave, pulse, triangle, and sawtooth waveforms which all used w % (2*pi) directly

Addresses sharpie7/circuitjs1#1023.

## Changes
- VoltageElm.java: Compute a normalized wn = ((w % (2*pi)) + 2*pi) % (2*pi) and use it in WF_SQUARE, WF_PULSE, WF_TRIANGLE, and WF_SAWTOOTH cases. WF_AC (sine) is unaffected since Math.sin handles any angle correctly.

## Test plan
- [ ] Set square wave source with negative phase shift (e.g. -90 degrees) and verify it starts at the correct value
- [ ] Set pulse source with negative phase shift and verify correct initial value
- [ ] Set triangle and sawtooth sources with negative phase shift and verify correct initial values
- [ ] Verify positive and zero phase shift still work correctly for all waveforms

Generated with [Claude Code](https://claude.com/claude-code)