### PR TITLE
Fix parseUnits() to accept scientific notation input

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/EditDialog.java
+++ b/src/com/lushprojects/circuitjs1/client/EditDialog.java
@@ -241,6 +241,13 @@ class EditDialog extends Dialog {
 		s=s.replaceAll("([0-9]+)([pPnNuUmMkKgG])([0-9]+)", "$1.$3$2");
 		// rewrite meg to M
 		s=s.replaceAll("[mM][eE][gG]$", "M");
+
+		// handle scientific notation (e.g. "4.416e-8", "1.2E+3", "5e9")
+		// before checking for unit suffixes, so that "e" is not
+		// misinterpreted and the value is not silently rejected
+		if (s.matches("^-?[0-9]*\\.?[0-9]+[eE][+-]?[0-9]+$"))
+		    return Double.parseDouble(s) * rmsMult;
+
 		int len = s.length();
 		char uc = s.charAt(len-1);
 		double mult = 1;


### PR DESCRIPTION
## Summary
- Fix `parseUnits()` in `EditDialog.java` to handle scientific notation (e.g. `4.416e-8`, `1.2E+3`, `5e9`)
- Previously, entering a value like `4.416e-8` in dialog fields (such as the diode model saturation current) would silently fail because GWT `NumberFormat.parse()` cannot handle scientific notation with the format pattern used
- The exception was caught silently in `apply()`, leaving the parameter unchanged with no feedback to the user
- Add a regex check before unit-suffix parsing: if the string matches scientific notation, use `Double.parseDouble()` which handles it natively

Fixes sharpie7/circuitjs1#1003

## Test plan
- [ ] Open a diode element, click "Edit Model", enter `4.416e-8` for Saturation Current -- should be accepted
- [ ] Verify standard unit suffixes still work: `100m`, `2.2k`, `10u`, `4.7n`
- [ ] Verify shorthand notation still works: `2k2`, `4n7`
- [ ] Verify `100rms` still works for voltage elements
- [ ] Verify uppercase scientific notation works: `1.2E+3`, `5E9`
- [ ] Verify negative scientific notation works: `-3.14e-2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)