### PR TITLE
Add logarithmic scale option to sliders

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/Adjustable.java
+++ b/src/com/lushprojects/circuitjs1/client/Adjustable.java
@@ -13,11 +13,13 @@ public class Adjustable implements Command {
     double sliderStep; // step increment; 0 = continuous (no stepping)
     int flags;
     String sliderText;
-    
+    boolean logarithmic;
+
     // null if this Adjustable has its own slider, non-null if it's sharing another one.
     Adjustable sharedSlider;
-    
+
     final int FLAG_SHARED = 1;
+    final int FLAG_LOG = 2;
     
     // index of value in getEditInfo() list that this slider controls
     int editItem;
@@ -62,6 +64,7 @@ public class Adjustable implements Command {
 	    }
 	    sliderText = CustomLogicModel.unescape(st.nextToken());
 	} catch (Exception ex) {}
+	logarithmic = (flags & FLAG_LOG) != 0;
 	try {
 	    sliderStep = Double.parseDouble(st.nextToken());
 	} catch (Exception ex) {}
@@ -88,7 +91,7 @@ public class Adjustable implements Command {
     void createSlider(CirSim sim, double value) {
         sim.addWidgetToVerticalPanel(label = new Label(Locale.LS(sliderText)));
         label.addStyleName("topSpace");
-        int intValue = (int) ((value-minValue)*100/(maxValue-minValue));
+        int intValue = valueToSliderPosition(value);
         sim.addWidgetToVerticalPanel(slider = new Scrollbar(Scrollbar.HORIZONTAL, intValue, 1, 0, 101, this, elm));
         slider.setStepSize(sliderStep * 100 / (maxValue - minValue));
     }
@@ -98,7 +101,7 @@ public class Adjustable implements Command {
 	    sharedSlider.setSliderValue(value);
 	    return;
 	}
-        int intValue = (int) ((value-minValue)*100/(maxValue-minValue));
+        int intValue = valueToSliderPosition(value);
         settingValue = true; // don't recursively set value again in execute()
         slider.setValue(intValue);
         settingValue = false;
@@ -126,11 +129,31 @@ public class Adjustable implements Command {
     
     double getSliderValue() {
 	double val = sharedSlider == null ? slider.getValue() : sharedSlider.slider.getValue();
-	double result = minValue + (maxValue-minValue)*val/100;
+	double result = sliderPositionToValue(val);
 	double step = sharedSlider != null ? sharedSlider.sliderStep : sliderStep;
 	if (step > 0)
 	    result = minValue + Math.round((result - minValue) / step) * step;
 	return result;
+    }
+
+    // convert a value to a slider position (0-100)
+    int valueToSliderPosition(double value) {
+	if (logarithmic && minValue > 0) {
+	    double logMin = Math.log(minValue);
+	    double logMax = Math.log(maxValue);
+	    return (int) ((Math.log(value) - logMin) / (logMax - logMin) * 100);
+	}
+	return (int) ((value - minValue) * 100 / (maxValue - minValue));
+    }
+
+    // convert a slider position (0-100) to a value
+    double sliderPositionToValue(double pos) {
+	if (logarithmic && minValue > 0) {
+	    double logMin = Math.log(minValue);
+	    double logMax = Math.log(maxValue);
+	    return Math.exp(logMin + (logMax - logMin) * pos / 100);
+	}
+	return minValue + (maxValue - minValue) * pos / 100;
     }
     
     void deleteSlider(CirSim sim) {
@@ -159,8 +182,14 @@ public class Adjustable implements Command {
 	int ano = -1;
 	if (sharedSlider != null)
 	    ano = CirSim.theApp.adjustables.indexOf(sharedSlider);
-	
-	return CirSim.theApp.locateElm(elm) + " F1 " + editItem + " " + minValue + " " + maxValue + " " + ano + " " +
+
+	int dumpFlags = 0;
+	if (sharedSlider != null)
+	    dumpFlags |= FLAG_SHARED;
+	if (logarithmic)
+	    dumpFlags |= FLAG_LOG;
+
+	return CirSim.theApp.locateElm(elm) + " F" + dumpFlags + " " + editItem + " " + minValue + " " + maxValue + " " + ano + " " +
 			CustomLogicModel.escape(sliderText) + " " + sliderStep;
     }
     

--- a/src/com/lushprojects/circuitjs1/client/SliderDialog.java
+++ b/src/com/lushprojects/circuitjs1/client/SliderDialog.java
@@ -42,6 +42,7 @@ class SliderDialog extends Dialog  {
 	CirSim sim;
 	Button applyButton, okButton, cancelButton;
 	EditInfo einfos[];
+	Checkbox logCheckboxes[];
 	int einfocount;
 	final int barmax = 1000;
 	VerticalPanel vp;
@@ -56,6 +57,7 @@ class SliderDialog extends Dialog  {
 		vp=new VerticalPanel();
 		setWidget(vp);
 		einfos = new EditInfo[10];
+		logCheckboxes = new Checkbox[10];
 		noCommaFormat=NumberFormat.getFormat("####.##########");
 		hp=new HorizontalPanel();
 		hp.setWidth("100%");
@@ -144,6 +146,8 @@ class SliderDialog extends Dialog  {
 			    vp.insert(new Label(Locale.LS("Step (0=continuous)")), idx++);
 			    ei.stepBox = new TextBox();
 			    vp.insert(ei.stepBox, idx++);
+			    logCheckboxes[i] = new Checkbox(Locale.LS("Logarithmic"), adj.logarithmic);
+			    vp.insert(logCheckboxes[i], idx++);
 			    if (adj.sharedSlider == null) {
 				// select label if this is a new slider
 				vp.insert(new Label(Locale.LS("Label")), idx++);
@@ -186,6 +190,11 @@ class SliderDialog extends Dialog  {
 			adj.sliderStep = d;
 			if (adj.slider != null && adj.maxValue != adj.minValue)
 			    adj.slider.setStepSize(d * 100 / (adj.maxValue - adj.minValue));
+			if (logCheckboxes[i] != null)
+			    adj.logarithmic = logCheckboxes[i].getState();
+			// guard: logarithmic requires minValue > 0
+			if (adj.logarithmic && adj.minValue <= 0)
+			    adj.logarithmic = false;
 			adj.setSliderValue(ei.value);
 		    } catch (Exception e) { CirSim.console(e.toString()); }
 		}
@@ -248,6 +257,8 @@ class SliderDialog extends Dialog  {
 	public void clearDialog() {
 		while (vp.getWidget(0)!=hp)
 			vp.remove(0);
+		for (int j = 0; j < logCheckboxes.length; j++)
+			logCheckboxes[j] = null;
 	}
 }
 

--- a/src/com/lushprojects/circuitjs1/client/XMLDeserializer.java
+++ b/src/com/lushprojects/circuitjs1/client/XMLDeserializer.java
@@ -141,6 +141,7 @@ class XMLDeserializer {
 		int ss = parseIntAttr("ss", -1);
 		if (ss != -1)
 		    adj.sharedSlider = app.adjustables.get(ss);
+		adj.logarithmic = parseIntAttr("log", 0) != 0;
 		app.adjustables.add(adj);
 		continue;
 	    }

--- a/src/com/lushprojects/circuitjs1/client/XMLSerializer.java
+++ b/src/com/lushprojects/circuitjs1/client/XMLSerializer.java
@@ -142,6 +142,8 @@ class XMLSerializer {
 		dumpAttr(ae, "stp", adj.sliderStep);
 	    if (adj.sharedSlider != null)
 		dumpAttr(ae, "ss", app.adjustables.indexOf(adj.sharedSlider));
+	    if (adj.logarithmic)
+		dumpAttr(ae, "log", 1);
 	    root.appendChild(ae);
 	}
 	if (app.hintType != -1) {


### PR DESCRIPTION
## Summary
- Adds a "Logarithmic" checkbox to the slider configuration dialog, allowing slider position to map exponentially between min and max values
- Essential for parameters spanning orders of magnitude (e.g., resistance 1 ohm to 10M ohm, capacitance 1pF to 1000uF)
- Gracefully falls back to linear if min value is zero or negative (cannot take log of non-positive numbers)
- Fully backward compatible: old circuits without the flag load as linear (default)

## Details

When logarithmic mode is enabled:
- **Slider position to value**: `exp(logMin + (logMax - logMin) * pos / 100)` -- the slider midpoint corresponds to the geometric mean of min and max
- **Value to slider position**: `(log(value) - logMin) / (logMax - logMin) * 100` -- inverse mapping

The logarithmic flag is persisted in both:
- **Text dump format**: via `FLAG_LOG` (bit 2) in the existing flags field (`F` prefix)
- **XML format**: via a `log` attribute on the `adj` element

Addresses sharpie7/circuitjs1#706.

## Test plan
- [ ] Add a slider to a resistor resistance value (e.g., 1 to 10M)
- [ ] Enable the Logarithmic checkbox and verify the slider midpoint is near geometric mean (~3.16k for 1-10M range)
- [ ] Verify linear mode still works as before when checkbox is unchecked
- [ ] Save and reload circuit, verify logarithmic state is preserved
- [ ] Test with min value of 0 -- verify it falls back to linear
- [ ] Test shared sliders with logarithmic mode

Generated with [Claude Code](https://claude.com/claude-code)