### PR TITLE
Add keyboard shortcut support to switches

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/CrossSwitchElm.java
+++ b/src/com/lushprojects/circuitjs1/client/CrossSwitchElm.java
@@ -222,14 +222,18 @@ package com.lushprojects.circuitjs1.client;
 	public EditInfo getEditInfo(int n) {
 	    if (n == 0)
 		return EditInfo.createCheckbox("IEC Symbol", useIECSymbol());
+	    if (n == 1)
+		return getKeyShortcutEditInfo();
 	    return null;
 	}
-	
+
 	public void setEditValue(int n, EditInfo ei) {
 	    if (n == 0) {
 		flags = ei.changeFlag(flags, FLAG_IEC);
 		setPoints();
 	    }
+	    if (n == 1)
+		setKeyShortcutEditValue(ei);
 	}
 
     }

--- a/src/com/lushprojects/circuitjs1/client/DPDTSwitchElm.java
+++ b/src/com/lushprojects/circuitjs1/client/DPDTSwitchElm.java
@@ -205,6 +205,8 @@ class DPDTSwitchElm extends SwitchElm {
 	    	return new EditInfo("# of Poles", poleCount, 2, 10).setDimensionless();
 	    if (n == 1)
 		return EditInfo.createCheckbox("IEC Symbol", useIECSymbol());
+	    if (n == 2)
+		return getKeyShortcutEditInfo();
 	    return null;
 	}
 	public void setEditValue(int n, EditInfo ei) {
@@ -217,6 +219,8 @@ class DPDTSwitchElm extends SwitchElm {
 		flags = ei.changeFlag(flags, FLAG_IEC);
 		setPoints();
 	    }
+	    if (n == 2)
+		setKeyShortcutEditValue(ei);
 	}
 	
 	int getShortcut() { return 0; }

--- a/src/com/lushprojects/circuitjs1/client/LogicInputElm.java
+++ b/src/com/lushprojects/circuitjs1/client/LogicInputElm.java
@@ -140,6 +140,8 @@ class LogicInputElm extends SwitchElm {
 		ei.checkbox = new Checkbox("Ternary", isTernary());
 		return ei;
 	    }
+	    if (n == 5)
+		return getKeyShortcutEditInfo();
 	    return null;
 	}
 	public void setEditValue(int n, EditInfo ei) {
@@ -162,6 +164,8 @@ class LogicInputElm extends SwitchElm {
 		    flags &= ~FLAG_TERNARY;
 		posCount = (isTernary()) ? 3 : 2;
 	    }
+	    if (n == 5)
+		setKeyShortcutEditValue(ei);
 	}
 	int getShortcut() { return 'i'; }
 	

--- a/src/com/lushprojects/circuitjs1/client/MBBSwitchElm.java
+++ b/src/com/lushprojects/circuitjs1/client/MBBSwitchElm.java
@@ -194,12 +194,16 @@ class MBBSwitchElm extends SwitchElm {
 	    	return new EditInfo("Switch Group", link, 0, 100).setDimensionless();
 	    if (n == 0)
 		return super.getEditInfo(n);
+	    if (n == 2)
+		return getKeyShortcutEditInfo();
 	    return null;
 	}
 	public void setEditValue(int n, EditInfo ei) {
 	    if (n == 1) {
 	    	link = (int) ei.value;
-	    } else
+	    } else if (n == 2)
+	    	setKeyShortcutEditValue(ei);
+	    else
 	    	super.setEditValue(n, ei);
 	}
 	int getShortcut() { return 0; }

--- a/src/com/lushprojects/circuitjs1/client/SwitchElm.java
+++ b/src/com/lushprojects/circuitjs1/client/SwitchElm.java
@@ -30,6 +30,7 @@ class SwitchElm extends CircuitElm {
     final int FLAG_IEC = 2;
     final int FLAG_LABEL = 4;
     String label;
+    String keyShortcut;
     
     public SwitchElm(int xx, int yy) {
 	super(xx, yy);
@@ -37,6 +38,7 @@ class SwitchElm extends CircuitElm {
 	position = 0;
 	posCount = 2;
 	label = null;
+	keyShortcut = null;
     }
     SwitchElm(int xx, int yy, boolean mm) {
 	super(xx, yy);
@@ -44,6 +46,7 @@ class SwitchElm extends CircuitElm {
 	momentary = mm;
 	posCount = 2;
 	label = null;
+	keyShortcut = null;
     }
     public SwitchElm(int xa, int ya, int xb, int yb, int f,
 		     StringTokenizer st) {
@@ -71,6 +74,8 @@ class SwitchElm extends CircuitElm {
             XMLSerializer.dumpAttr(elem, "mm", momentary);
 	if (label != null)
             XMLSerializer.dumpAttr(elem, "lab", label);
+	if (keyShortcut != null)
+	    XMLSerializer.dumpAttr(elem, "key", keyShortcut);
     }
 
     void undumpXml(XMLDeserializer xml) {
@@ -78,6 +83,7 @@ class SwitchElm extends CircuitElm {
         position = xml.parseIntAttr("p", position);
         momentary = xml.parseBooleanAttr("mm", momentary);
         label = xml.parseStringAttr("lab", label);
+        keyShortcut = xml.parseStringAttr("key", keyShortcut);
     }
 
     Point ps, ps2;
@@ -214,6 +220,8 @@ class SwitchElm extends CircuitElm {
 	    return EditInfo.createCheckbox("IEC Symbol", useIECSymbol());
         if (n == 2)
             return new EditInfo("Label (for linking)", label == null ? "" : label);
+	if (n == 3)
+	    return getKeyShortcutEditInfo();
 	return null;
     }
     public void setEditValue(int n, EditInfo ei) {
@@ -231,6 +239,21 @@ class SwitchElm extends CircuitElm {
             } else
         	flags |= FLAG_LABEL;
         }
+	if (n == 3)
+	    setKeyShortcutEditValue(ei);
+    }
+
+    // helper methods for keyboard shortcut edit field, usable by subclasses
+    EditInfo getKeyShortcutEditInfo() {
+	return new EditInfo("Keyboard Shortcut", keyShortcut == null ? "" : keyShortcut);
+    }
+
+    void setKeyShortcutEditValue(EditInfo ei) {
+	String s = ei.textf.getText().trim();
+	if (s.length() == 0)
+	    keyShortcut = null;
+	else
+	    keyShortcut = s.substring(0, 1).toLowerCase();
     }
 
     int getShortcut() { return 's'; }

--- a/src/com/lushprojects/circuitjs1/client/UIManager.java
+++ b/src/com/lushprojects/circuitjs1/client/UIManager.java
@@ -998,6 +998,27 @@ public class UIManager {
     	if (isReadOnly())
     	    return;
 
+    	// handle key-up for momentary switches with keyboard shortcuts
+    	if ((t & Event.ONKEYUP) != 0) {
+    	    String keyStr = String.valueOf((char)code).toLowerCase();
+    	    boolean released = false;
+    	    for (int i = 0; i != elmList.size(); i++) {
+    		CircuitElm ce = elmList.get(i);
+    		if (ce instanceof SwitchElm) {
+    		    SwitchElm se = (SwitchElm) ce;
+    		    if (se.momentary && se.keyShortcut != null && se.keyShortcut.equals(keyStr)) {
+    			se.mouseUp();
+    			released = true;
+    		    }
+    		}
+    	    }
+    	    if (released) {
+    		mouse.heldSwitchElm = null;
+    		app.needAnalyze();
+    		app.repaint();
+    	    }
+    	}
+
     	if ((t & Event.ONKEYDOWN)!=0) {
     		if (code==KEY_BACKSPACE || code==KEY_DELETE) {
     		    if (app.scopeManager.scopeSelected != -1) {
@@ -1069,7 +1090,26 @@ public class UIManager {
     		}
     	}
     	if ((t&Event.ONKEYPRESS)!=0) {
-    		if (cc>32 && cc<127){
+    		// check if any switches have a keyboard shortcut matching this key
+    		if (cc>32 && cc<127) {
+    		    String keyStr = String.valueOf((char)cc).toLowerCase();
+    		    boolean toggled = false;
+    		    for (int i = 0; i != elmList.size(); i++) {
+    			CircuitElm ce = elmList.get(i);
+    			if (ce instanceof SwitchElm) {
+    			    SwitchElm se = (SwitchElm) ce;
+    			    if (se.keyShortcut != null && se.keyShortcut.equals(keyStr)) {
+    				se.toggle();
+    				if (!(se instanceof LogicInputElm))
+    				    app.needAnalyze();
+    				toggled = true;
+    			    }
+    			}
+    		    }
+    		    if (toggled) {
+    			e.cancel();
+    			app.repaint();
+    		    } else {
     			String c=app.shortcuts[cc];
     			e.cancel();
     			if (c==null)
@@ -1078,6 +1118,7 @@ public class UIManager {
     			mouseModeStr=c;
 			updateToolbar();
     			mouse.tempMouseMode = mouse.mouseMode;
+    		    }
     		}
     		if (cc==32) {
 		    setMouseMode(MouseManager.MODE_SELECT);


### PR DESCRIPTION
## Summary

- Adds a "Keyboard Shortcut" field to the edit dialog of all switch types (SPST, SPDT, push, DPDT, cross, make-before-break, and logic input)
- When the assigned key is pressed, the switch toggles; momentary switches release on key-up
- Multiple switches sharing the same shortcut key all toggle together (useful for ganged switches)
- Keyboard shortcuts take priority over element-placement shortcuts when assigned
- Persisted via XML serialization (`key` attribute), fully backward-compatible

## Details

A `keyShortcut` field is added to `SwitchElm` (the base class for all switch types). Helper methods `getKeyShortcutEditInfo()` and `setKeyShortcutEditValue()` are provided for subclasses that override `getEditInfo`/`setEditValue`. The keyboard handler in `UIManager.onPreviewNativeEvent` checks for matching switches on `ONKEYPRESS` and handles momentary switch release on `ONKEYUP`.

Addresses sharpie7/circuitjs1#869.

## Test plan

- [ ] Place an SPST switch, open its edit dialog, enter "a" as the keyboard shortcut
- [ ] Press "a" on the keyboard and verify the switch toggles
- [ ] Place a momentary push switch, assign shortcut "b", hold "b" and verify it closes, release "b" and verify it opens
- [ ] Place two SPST switches with the same shortcut "c", press "c" and verify both toggle
- [ ] Place an SPDT switch, assign shortcut "d", verify toggling works
- [ ] Place a logic input, assign shortcut "e", verify toggling works
- [ ] Save and reload the circuit, verify keyboard shortcuts are preserved
- [ ] Verify that unassigned keys still work for element placement shortcuts (e.g., "r" for resistor)
- [ ] Verify that a key assigned to a switch overrides the element placement shortcut for that key

🤖 Generated with [Claude Code](https://claude.com/claude-code)