### PR TITLE
Add configurable propagation delay to logic gates

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/GateElm.java
+++ b/src/com/lushprojects/circuitjs1/client/GateElm.java
@@ -29,6 +29,8 @@ abstract class GateElm extends CircuitElm {
 	int inputCount = 2;
 	boolean lastOutput;
 	double highVoltage;
+	double propagationDelay; // seconds; 0 = instant (default)
+	double delayEndTime;     // time at which pending output change takes effect
 	public static double lastHighVoltage = 5;
 	static boolean lastSchmitt = false;
 	
@@ -55,6 +57,7 @@ abstract class GateElm extends CircuitElm {
 	    highVoltage = 5;
 	    try {
 		highVoltage = new Double(st.nextToken()).doubleValue();
+		propagationDelay = new Double(st.nextToken()).doubleValue();
 	    } catch (Exception e) { }
 	    lastOutput = lastOutputVoltage > highVoltage*.5;
 	    setSize((f & FLAG_SMALL) != 0 ? 1 : 2);
@@ -72,7 +75,7 @@ abstract class GateElm extends CircuitElm {
 	    flags |= (s == 1) ? FLAG_SMALL : 0;
 	}
 	String dump() {
-	    return super.dump() + " " + inputCount + " " + volts[inputCount] + " " + highVoltage;
+	    return super.dump() + " " + inputCount + " " + volts[inputCount] + " " + highVoltage + " " + propagationDelay;
 	}
 
 	void dumpXml(Document doc, Element elem) {
@@ -81,6 +84,8 @@ abstract class GateElm extends CircuitElm {
 		XMLSerializer.dumpAttr(elem, "hi", highVoltage);
 	    if (inputCount != 2)
 		XMLSerializer.dumpAttr(elem, "in", inputCount);
+	    if (propagationDelay != 0)
+		XMLSerializer.dumpAttr(elem, "pd", propagationDelay);
 	}
 
 	void dumpXmlState(Document doc, Element elem) {
@@ -93,6 +98,7 @@ abstract class GateElm extends CircuitElm {
 	    super.undumpXml(xml);
 	    highVoltage = xml.parseDoubleAttr("hi", highVoltage);
 	    inputCount = xml.parseIntAttr("in", inputCount);
+	    propagationDelay = xml.parseDoubleAttr("pd", 0);
 	    double lastOutputVoltage = xml.parseDoubleAttr("o", 0);
 	    lastOutput = lastOutputVoltage > highVoltage*.5;
 	    setSize((flags & FLAG_SMALL) != 0 ? 1 : 2);
@@ -210,6 +216,8 @@ abstract class GateElm extends CircuitElm {
 	    arr[0] = getGateName();
 	    arr[1] = "Vout = " + getVoltageText(volts[inputCount]);
 	    arr[2] = "Iout = " + getCurrentText(getCurrent());
+	    if (propagationDelay > 0)
+		arr[3] = "delay = " + getUnitText(propagationDelay, "s");
 	}
 	void stamp() {
 	    sim.stampVoltageSource(0, nodes[inputCount], voltSource);
@@ -232,7 +240,7 @@ abstract class GateElm extends CircuitElm {
 	    boolean f = calcFunction();
 	    if (isInverting())
 		f = !f;
-	    
+
 	    if (lastTime != sim.t) {
 		// detect oscillation (using same strategy as Atanua)
 		if (lastOutput == !f) {
@@ -244,12 +252,25 @@ abstract class GateElm extends CircuitElm {
 		    }
 		} else
 		    oscillationCount = 0;
-	    
-		lastOutput = f;
+
 		lastTime = sim.t;
 	    }
-	    
-	    double res = f ? highVoltage : 0;
+
+	    // apply propagation delay if configured
+	    if (propagationDelay > 0) {
+		if (f != lastOutput) {
+		    // desired output differs from current output; wait for delay
+		    if (sim.t >= delayEndTime)
+			lastOutput = f;
+		} else {
+		    // output matches desired; reset the delay timer
+		    delayEndTime = sim.t + propagationDelay;
+		}
+	    } else {
+		lastOutput = f;
+	    }
+
+	    double res = lastOutput ? highVoltage : 0;
 	    sim.updateVoltageSource(0, nodes[inputCount], voltSource, res);
 	}
 	public EditInfo getEditInfo(int n) {
@@ -262,6 +283,8 @@ abstract class GateElm extends CircuitElm {
 		return EditInfo.createCheckbox("Schmitt Inputs", hasSchmittInputs());
 	    if (n == 3)
 		return EditInfo.createCheckbox("Invert Inputs", hasFlag(FLAG_INVERT_INPUTS));
+	    if (n == 4)
+		return new EditInfo("Propagation Delay (s)", propagationDelay, 0, 0);
 	    return null;
 	}
 
@@ -286,6 +309,8 @@ abstract class GateElm extends CircuitElm {
 		flags = ei.changeFlag(flags, FLAG_INVERT_INPUTS);
 		setPoints();
 	    }
+	    if (n == 4)
+		propagationDelay = ei.value;
 	}
 	// there is no current path through the gate inputs, but there
 	// is an indirect path through the output to ground.

--- a/src/com/lushprojects/circuitjs1/client/XorGateElm.java
+++ b/src/com/lushprojects/circuitjs1/client/XorGateElm.java
@@ -36,10 +36,16 @@ package com.lushprojects.circuitjs1.client;
 	}
 	
 	public EditInfo getEditInfo(int n) {
-	    // no invert inputs option
-	    if (n == 3)
-		return null;
+	    // skip "Invert Inputs" (index 3 in GateElm); shift higher indices down
+	    if (n >= 3)
+		return super.getEditInfo(n + 1);
 	    return super.getEditInfo(n);
+	}
+	public void setEditValue(int n, EditInfo ei) {
+	    if (n >= 3)
+		super.setEditValue(n + 1, ei);
+	    else
+		super.setEditValue(n, ei);
 	}
 	
 	int getDumpType() { return 154; }


### PR DESCRIPTION
## Summary

- Adds a per-gate **Propagation Delay (s)** parameter to all logic gates (AND, OR, NAND, NOR, XOR, XNOR) via the `GateElm` base class
- Default is 0 (instant, preserving existing behavior); when non-zero, the gate output is delayed by the configured amount before switching
- Uses the same delay pattern as `DelayBufferElm`: when the computed output differs from the current output, the gate waits until the delay period elapses before updating
- Fully backwards-compatible: text dump appends the new field after `highVoltage` (parsed in try-catch), XML uses a new `pd` attribute (omitted when 0)
- Fixes `XorGateElm.getEditInfo()` to properly skip the "Invert Inputs" field without breaking the edit field chain, so propagation delay appears for XOR/XNOR gates too
- Displays delay in the info panel when non-zero

## Motivation

Configurable propagation delay enables realistic digital timing simulations including race conditions, setup/hold violations, pipelining demonstrations, and self-clocked flip-flop applications.

Addresses sharpie7/circuitjs1#813.

## Test plan

- [ ] Place an AND gate, open edit dialog, verify "Propagation Delay (s)" field appears with default 0
- [ ] Set propagation delay to e.g. 1ms, connect a clock input, verify output transitions are delayed
- [ ] Verify all gate types show the field: AND, OR, NAND, NOR, XOR, XNOR
- [ ] Verify XOR/XNOR gates show the propagation delay field (previously n==3 returned null which would have broken the chain)
- [ ] Save and reload a circuit with non-zero propagation delay, verify the value persists (both text and XML formats)
- [ ] Verify gates with delay=0 behave identically to before (no regression)
- [ ] Hover over a gate with delay set, verify info panel shows the delay value

🤖 Generated with [Claude Code](https://claude.com/claude-code)