### PR TITLE
Color logic gate pins by logical state (high/low)

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/ChipElm.java
+++ b/src/com/lushprojects/circuitjs1/client/ChipElm.java
@@ -97,12 +97,16 @@ abstract class ChipElm extends CircuitElm {
 		    hasVertical = true;
 		    break;
 		}
+	    double threshold = getThreshold();
 	    for (i = 0; i != getPostCount(); i++) {
 		g.setFont(f);
 		Pin p = pins[i];
 		if (p.busZ > 0)
 		    continue;
-		setVoltageColor(g, volts[i]);
+		if (isDigitalChip())
+		    setLogicPinColor(g, volts[i], threshold);
+		else
+		    setVoltageColor(g, volts[i]);
 		Point a = p.post;
 		Point b = p.stub;
 		drawThickLine(g, a, b, p.busWidth > 1 ? 5 : 3);

--- a/src/com/lushprojects/circuitjs1/client/CircuitElm.java
+++ b/src/com/lushprojects/circuitjs1/client/CircuitElm.java
@@ -60,7 +60,11 @@ public abstract class CircuitElm implements Editable {
     static final int SCALE_MU = 3;
     
     static int decimalDigits, shortDecimalDigits;
- 
+
+    // when true, logic gate/chip pin leads are colored by logical state (high/low)
+    // rather than by analog voltage
+    static boolean colorLogicPins;
+
     // initial point where user created element.  For simple two-terminal elements, this is the first node/post.
     int x, y;
     
@@ -1116,7 +1120,22 @@ public abstract class CircuitElm implements Editable {
     void setVoltageColor(Graphics g, double volts) {
     	g.setColor(getVoltageColor(g, volts));
     }
-    
+
+    // Set pin color based on logical state (high/low) relative to a threshold.
+    // Used by logic gates and chips when colorLogicPins is enabled.
+    // Falls back to normal voltage coloring when the option is off.
+    void setLogicPinColor(Graphics g, double volts, double threshold) {
+	if (colorLogicPins) {
+	    if (needsHighlight()) {
+		g.setColor(selectColor);
+		return;
+	    }
+	    g.setColor(volts > threshold ? positiveColor : neutralColor);
+	} else {
+	    setVoltageColor(g, volts);
+	}
+    }
+
     // yellow argument is unused, can't remember why it was there
     void setPowerColor(Graphics g, boolean yellow) {
 

--- a/src/com/lushprojects/circuitjs1/client/DelayBufferElm.java
+++ b/src/com/lushprojects/circuitjs1/client/DelayBufferElm.java
@@ -64,7 +64,10 @@ class DelayBufferElm extends CircuitElm {
 	
 	void draw(Graphics g) {
 	    drawPosts(g);
-	    draw2Leads(g);
+	    setLogicPinColor(g, volts[0], threshold);
+	    drawThickLine(g, point1, lead1);
+	    setLogicPinColor(g, volts[1], threshold);
+	    drawThickLine(g, lead2, point2);
 	    g.setColor(needsHighlight() ? selectColor : lightGrayColor);
 	    drawThickPolygon(g, gatePoly);
 	    if (GateElm.useEuroGates())

--- a/src/com/lushprojects/circuitjs1/client/EditOptions.java
+++ b/src/com/lushprojects/circuitjs1/client/EditOptions.java
@@ -93,10 +93,15 @@ class EditOptions implements Editable {
 		}
 		if (n == 15) {
 		    EditInfo ei = new EditInfo("", 0, -1, -1);
+		    ei.checkbox = new Checkbox("Color Logic Pins by State", CircuitElm.colorLogicPins);
+		    return ei;
+		}
+		if (n == 16) {
+		    EditInfo ei = new EditInfo("", 0, -1, -1);
 		    ei.checkbox = new Checkbox("Auto-Adjust Timestep", sim.adjustTimeStep);
 		    return ei;
 		}
-		if (n == 16 && sim.adjustTimeStep)
+		if (n == 17 && sim.adjustTimeStep)
 		    return new EditInfo("Minimum time step size (s)", sim.minTimeStep, 0, 0).setPositive();
 
 		// don't add new options here.  they are only visible if sim.adjustTimeStemp is set, and it isn't by default.
@@ -194,10 +199,14 @@ class EditOptions implements Editable {
                 if (n == 14)
                     app.autoDCOnReset = ei.checkbox.getState();
 		if (n == 15) {
+		    CircuitElm.colorLogicPins = ei.checkbox.getState();
+		    app.setOptionInStorage("colorLogicPins", CircuitElm.colorLogicPins);
+		}
+		if (n == 16) {
 		    sim.adjustTimeStep = ei.checkbox.getState();
 		    ei.newDialog = true;
 		}
-		if (n == 16)
+		if (n == 17 && ei.value > 0)
 		    sim.minTimeStep = ei.value;
 	}
 

--- a/src/com/lushprojects/circuitjs1/client/GateElm.java
+++ b/src/com/lushprojects/circuitjs1/client/GateElm.java
@@ -183,11 +183,12 @@ abstract class GateElm extends CircuitElm {
 	
 	void draw(Graphics g) {
 	    int i;
+	    double threshold = highVoltage * .5;
 	    for (i = 0; i != inputCount; i++) {
-		setVoltageColor(g, volts[i]);
+		setLogicPinColor(g, volts[i], threshold);
 		drawThickLine(g, inPosts[i], inGates[i]);
 	    }
-	    setVoltageColor(g, volts[inputCount]);
+	    setLogicPinColor(g, volts[inputCount], threshold);
 	    drawThickLine(g, lead2, point2);
 	    g.setColor(needsHighlight() ? selectColor : lightGrayColor);
 	    if (useEuroGates()) {

--- a/src/com/lushprojects/circuitjs1/client/InverterElm.java
+++ b/src/com/lushprojects/circuitjs1/client/InverterElm.java
@@ -67,7 +67,11 @@ class InverterElm extends CircuitElm {
 	
 	void draw(Graphics g) {
 	    drawPosts(g);
-	    draw2Leads(g);
+	    double threshold = highVoltage * .5;
+	    setLogicPinColor(g, volts[0], threshold);
+	    drawThickLine(g, point1, lead1);
+	    setLogicPinColor(g, volts[1], threshold);
+	    drawThickLine(g, lead2, point2);
 	    g.setColor(needsHighlight() ? selectColor : lightGrayColor);
 	    drawThickPolygon(g, gatePoly);
 	    if (GateElm.useEuroGates())

--- a/src/com/lushprojects/circuitjs1/client/TriStateElm.java
+++ b/src/com/lushprojects/circuitjs1/client/TriStateElm.java
@@ -128,18 +128,22 @@ class TriStateElm extends CircuitElm {
 	int hs = 16;
 	setBbox(point1, point2, hs);
 
-	// draw control lead underneath the triangle
-	setVoltageColor(g, volts[2 * busWidth]);
+	double threshold = highVoltage * .5;
+	// control lead
+	setLogicPinColor(g, volts[2 * busWidth], threshold);
 	drawThickLine(g, point3, lead3);
 
-	// draw leads with bus thickness if bus mode
+	// input/output leads (bus-thick in bus mode)
 	if (busWidth > 1) {
-	    setVoltageColor(g, volts[0]);
+	    setLogicPinColor(g, volts[0], threshold);
 	    drawThickLine(g, point1, busLead1, 5);
-	    setVoltageColor(g, volts[busWidth]);
+	    setLogicPinColor(g, volts[busWidth], threshold);
 	    drawThickLine(g, lead2, point2, 5);
 	} else {
-	    draw2Leads(g);
+	    setLogicPinColor(g, volts[0], threshold);
+	    drawThickLine(g, point1, lead1);
+	    setLogicPinColor(g, volts[busWidth], threshold);
+	    drawThickLine(g, lead2, point2);
 	}
 
 	g.setColor(lightGrayColor);

--- a/src/com/lushprojects/circuitjs1/client/UIManager.java
+++ b/src/com/lushprojects/circuitjs1/client/UIManager.java
@@ -140,6 +140,7 @@ public class UIManager {
 		       getOptionFromStorage("conventionalCurrent", true));
 	    noEditing = !qp.getBooleanValue("editable", true);
 	    mouseWheelEdit = qp.getBooleanValue("mouseWheelEdit", getOptionFromStorage("mouseWheelEdit", true));
+	    CircuitElm.colorLogicPins = getOptionFromStorage("colorLogicPins", false);
 	    positiveColor = qp.getValue("positiveColor");
 	    negativeColor = qp.getValue("negativeColor");
 	    neutralColor = qp.getValue("neutralColor");


### PR DESCRIPTION
## Summary

- Adds a toggleable "Color Logic Pins by State" option in Other Options (persisted via localStorage, off by default)
- When enabled, logic gate and chip pin leads are colored based on whether the pin voltage is above or below the logic threshold: **high pins show in the positive color** (green by default), **low pins show in the neutral color** (gray by default)
- Makes signal propagation visually traceable through logic circuits without affecting the existing voltage-gradient coloring system for wires and non-logic elements

## Affected elements

- `GateElm` (AND, OR, XOR, NAND, NOR, XNOR and all subclasses)
- `ChipElm` (all digital chips: flip-flops, counters, shift registers, etc.)
- `InverterElm`
- `TriStateElm`
- `DelayBufferElm`

## Implementation details

- New `CircuitElm.colorLogicPins` static boolean field, loaded from localStorage on startup
- New `CircuitElm.setLogicPinColor(g, volts, threshold)` helper method that either applies logic-state coloring or falls back to the standard `setVoltageColor()` when the option is disabled
- Each logic element's `draw()` method uses `setLogicPinColor()` instead of `setVoltageColor()` for pin leads, with the element's own threshold (typically `highVoltage * 0.5`)
- Non-digital `ChipElm` subclasses (e.g. `OpAmpElm`) continue to use standard voltage coloring
- No changes to wire coloring or non-logic elements

## Test plan

- [ ] Open a logic circuit (e.g. any circuit with AND/OR/NOT gates)
- [ ] Verify pins display using normal voltage-gradient coloring by default
- [ ] Open Other Options, enable "Color Logic Pins by State"
- [ ] Verify HIGH pins turn the positive color (green) and LOW pins turn the neutral color (gray)
- [ ] Verify digital chips (flip-flops, counters) also show logic-state coloring
- [ ] Verify non-logic elements (resistors, capacitors, op-amps) are unaffected
- [ ] Verify the setting persists across page reloads (localStorage)
- [ ] Verify toggling the option off restores normal voltage coloring

Addresses sharpie7/circuitjs1#369.

🤖 Generated with [Claude Code](https://claude.com/claude-code)