### PR TITLE
Color MOSFET and op-amp by operating region

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/CircuitElm.java
+++ b/src/com/lushprojects/circuitjs1/client/CircuitElm.java
@@ -60,7 +60,9 @@ public abstract class CircuitElm implements Editable {
     static final int SCALE_MU = 3;
     
     static int decimalDigits, shortDecimalDigits;
- 
+
+    static boolean showOperatingRegion;
+
     // initial point where user created element.  For simple two-terminal elements, this is the first node/post.
     int x, y;
     
@@ -1231,6 +1233,7 @@ public abstract class CircuitElm implements Editable {
     int getShortcut() { return 0; }
     boolean showValues() { return app.menus.showValuesCheckItem.getState(); }
     boolean showPower() { return app.menus.powerCheckItem.getState(); }
+    boolean showOperatingRegion() { return showOperatingRegion; }
     boolean showEuroResistors() { return app.menus.euroResistorCheckItem.getState(); }
     boolean useSmallGrid() { return app.menus.smallGridCheckItem.getState(); }
     boolean doDcAnalysis() { return app.dcAnalysisFlag; }

--- a/src/com/lushprojects/circuitjs1/client/EditOptions.java
+++ b/src/com/lushprojects/circuitjs1/client/EditOptions.java
@@ -93,10 +93,15 @@ class EditOptions implements Editable {
 		}
 		if (n == 15) {
 		    EditInfo ei = new EditInfo("", 0, -1, -1);
+		    ei.checkbox = new Checkbox("Show Operating Region", CircuitElm.showOperatingRegion);
+		    return ei;
+		}
+		if (n == 16) {
+		    EditInfo ei = new EditInfo("", 0, -1, -1);
 		    ei.checkbox = new Checkbox("Auto-Adjust Timestep", sim.adjustTimeStep);
 		    return ei;
 		}
-		if (n == 16 && sim.adjustTimeStep)
+		if (n == 17 && sim.adjustTimeStep)
 		    return new EditInfo("Minimum time step size (s)", sim.minTimeStep, 0, 0).setPositive();
 
 		// don't add new options here.  they are only visible if sim.adjustTimeStemp is set, and it isn't by default.
@@ -194,10 +199,16 @@ class EditOptions implements Editable {
                 if (n == 14)
                     app.autoDCOnReset = ei.checkbox.getState();
 		if (n == 15) {
+		    CircuitElm.showOperatingRegion = ei.checkbox.getState();
+		    Storage stor = Storage.getLocalStorageIfSupported();
+		    if (stor != null)
+			stor.setItem("showOperatingRegion", CircuitElm.showOperatingRegion ? "true" : "false");
+		}
+		if (n == 16) {
 		    sim.adjustTimeStep = ei.checkbox.getState();
 		    ei.newDialog = true;
 		}
-		if (n == 16)
+		if (n == 17 && ei.value > 0)
 		    sim.minTimeStep = ei.value;
 	}
 

--- a/src/com/lushprojects/circuitjs1/client/MosfetElm.java
+++ b/src/com/lushprojects/circuitjs1/client/MosfetElm.java
@@ -148,6 +148,21 @@ class MosfetElm extends CircuitElm implements MouseWheelHandler {
 		setVoltageColor(g, volts[2]);
 		drawThickLine(g, drn[0], drn[1]);
 		
+		// draw operating region indicator on channel
+		if (showOperatingRegion()) {
+		    Color regionColor;
+		    if (mode == 0)
+			regionColor = Color.gray;         // cutoff
+		    else if (mode == 1)
+			regionColor = new Color(64, 128, 255);  // linear/triode - blue
+		    else
+			regionColor = new Color(0, 192, 0);     // saturation - green
+		    g.setColor(regionColor);
+		    g.setLineWidth(6);
+		    g.drawLine(src[1], drn[1]);
+		    g.setLineWidth(3);
+		}
+
 		// draw line connecting source and drain
 		int segments = 6;
 		int i;

--- a/src/com/lushprojects/circuitjs1/client/OpAmpElm.java
+++ b/src/com/lushprojects/circuitjs1/client/OpAmpElm.java
@@ -96,6 +96,19 @@ import com.google.gwt.xml.client.Document;
 	    drawThickLine(g, in2p[0], in2p[1]);
 	    setVoltageColor(g, volts[2]);
 	    drawThickLine(g, lead2, point2);
+	    // draw operating region indicator (saturation coloring)
+	    if (showOperatingRegion()) {
+		double saturationMargin = (maxOut - minOut) * 0.01;
+		if (saturationMargin < 0.01)
+		    saturationMargin = 0.01;
+		if (volts[2] >= maxOut - saturationMargin) {
+		    g.setColor(new Color(180, 60, 60));  // positive saturation - red tint
+		    g.fillPolygon(triangle);
+		} else if (volts[2] <= minOut + saturationMargin) {
+		    g.setColor(new Color(60, 60, 180));  // negative saturation - blue tint
+		    g.fillPolygon(triangle);
+		}
+	    }
 	    g.setColor(needsHighlight() ? selectColor : lightGrayColor);
 	    setPowerColor(g, true);
 	    drawThickPolygon(g, triangle);

--- a/src/com/lushprojects/circuitjs1/client/OpAmpRealElm.java
+++ b/src/com/lushprojects/circuitjs1/client/OpAmpRealElm.java
@@ -191,6 +191,22 @@ public class OpAmpRealElm extends CompositeElm {
         drawThickLine(g, rail1p[0], rail1p[1]);
         setVoltageColor(g, volts[4]);
         drawThickLine(g, rail2p[0], rail2p[1]);
+        // draw operating region indicator (saturation coloring)
+        if (showOperatingRegion()) {
+            double vPlus = volts[3];
+            double vMinus = volts[4];
+            double range = vPlus - vMinus;
+            double saturationMargin = range * 0.02;
+            if (saturationMargin < 0.05)
+                saturationMargin = 0.05;
+            if (volts[2] >= vPlus - saturationMargin) {
+                g.setColor(new Color(180, 60, 60));  // positive saturation - red tint
+                g.fillPolygon(triangle);
+            } else if (volts[2] <= vMinus + saturationMargin) {
+                g.setColor(new Color(60, 60, 180));  // negative saturation - blue tint
+                g.fillPolygon(triangle);
+            }
+        }
         g.setColor(needsHighlight() ? selectColor : lightGrayColor);
         setPowerColor(g, true);
         drawThickPolygon(g, triangle);

--- a/src/com/lushprojects/circuitjs1/client/UIManager.java
+++ b/src/com/lushprojects/circuitjs1/client/UIManager.java
@@ -241,6 +241,8 @@ public class UIManager {
 	menus.noEditCheckItem.setState(noEditing);
 	menus.mouseWheelEditCheckItem.setState(mouseWheelEdit);
 
+	CircuitElm.showOperatingRegion = getOptionFromStorage("showOperatingRegion", false);
+
 	loadShortcuts();
 
 	DOM.appendChild(layoutPanel.getElement(), topPanelCheckbox);


### PR DESCRIPTION
## Summary

- MOSFETs display a colored channel indicator showing their operating region: gray for cutoff, blue for linear/triode, green for saturation
- Op-amps (both ideal `OpAmpElm` and real `OpAmpRealElm`) show a colored fill when the output is saturating: red tint for positive rail clipping, blue tint for negative rail clipping
- Feature is toggled via **Other Options > Show Operating Region**, persisted in `localStorage`, and off by default

## Details

The MOSFET already tracks its operating region in the `mode` variable (0=cutoff, 1=linear, 2=saturation). This PR draws a wider colored line behind the channel segments to visually indicate the region. The colors are chosen to be distinct and meaningful: gray suggests no conduction, blue suggests resistive/linear behavior, and green suggests active/saturation operation.

For op-amps, the output voltage is compared against the supply rails. The ideal op-amp checks against `maxOut`/`minOut`, while the real op-amp checks against the actual supply voltages (`volts[3]`/`volts[4]`). When saturating, the triangle body is filled with a muted red or blue to indicate which rail the output is clipping to.

JFETs (`JfetElm`) inherit the MOSFET coloring automatically since they extend `MosfetElm`.

### Files changed

- `CircuitElm.java` — added `static boolean showOperatingRegion` field and `showOperatingRegion()` accessor
- `EditOptions.java` — added "Show Operating Region" checkbox at index 14 (shifted existing options)
- `UIManager.java` — initialize `showOperatingRegion` from `localStorage` on startup
- `MosfetElm.java` — draw colored channel background based on `mode` (cutoff/linear/saturation)
- `OpAmpElm.java` — fill triangle when output is near supply rails
- `OpAmpRealElm.java` — fill triangle when output is near actual supply voltages

## Test plan

- [ ] Place an N-MOSFET in a circuit, verify channel shows gray when Vgs < Vth
- [ ] Drive the MOSFET into linear region (Vds < Vgs-Vth), verify blue channel
- [ ] Drive the MOSFET into saturation (Vds > Vgs-Vth), verify green channel
- [ ] Verify P-MOSFET and JFET also show correct operating region colors
- [ ] Place an op-amp with output driven to positive rail, verify red fill
- [ ] Place an op-amp with output driven to negative rail, verify blue fill
- [ ] Verify op-amp shows no fill during normal linear operation
- [ ] Test with OpAmpRealElm (LM741/LM324) as well
- [ ] Toggle "Show Operating Region" off in Other Options, verify no coloring
- [ ] Verify option persists across page reloads via localStorage
- [ ] Verify existing rendering (voltage colors, power colors, dots) is unaffected

Addresses sharpie7/circuitjs1#846.

🤖 Generated with [Claude Code](https://claude.com/claude-code)