### PR TITLE
Add IEC diamond symbol option for dependent sources

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/VCCSElm.java
+++ b/src/com/lushprojects/circuitjs1/client/VCCSElm.java
@@ -25,6 +25,7 @@ import com.google.gwt.xml.client.Element;
 import com.lushprojects.circuitjs1.client.util.Locale;
 
 class VCCSElm extends ChipElm {
+	static final int FLAG_DIAMOND = 4;
 	double gain;
 	int inputCount;
 	Expr expr;
@@ -78,6 +79,22 @@ class VCCSElm extends ChipElm {
 	String getChipName() { return "VCCS~"; } // ~ is for localization 
 	boolean nonLinear() { return true; }
 	@Override boolean isDigitalChip() { return false; }
+	boolean useDiamondSymbol() { return (flags & FLAG_DIAMOND) != 0; }
+
+	void setPoints() {
+	    super.setPoints();
+	    if (useDiamondSymbol()) {
+		// replace the rectangle with a diamond (rotated square)
+		int xr = rectPointsX[0];
+		int yr = rectPointsY[0];
+		int xs = rectPointsX[1] - xr;
+		int ys = rectPointsY[2] - yr;
+		int cx = xr + xs/2;
+		int cy = yr + ys/2;
+		rectPointsX = new int[] { cx, xr+xs, cx, xr };
+		rectPointsY = new int[] { yr, cy, yr+ys, cy };
+	    }
+	}
 
 	void stamp() {
             sim.stampNonLinear(nodes[inputCount]);
@@ -190,6 +207,8 @@ class VCCSElm extends ChipElm {
             if (n == 1)
                 return new EditInfo("# of Inputs", inputCount, 1, 8).
                     setDimensionless();
+            if (n == 2)
+                return EditInfo.createCheckbox("IEC Diamond Symbol", useDiamondSymbol());
             return null;
         }
         public void setChipEditValue(int n, EditInfo ei) {
@@ -204,6 +223,10 @@ class VCCSElm extends ChipElm {
                 inputCount = (int) ei.value;
                 setupPins();
                 allocNodes();
+                setPoints();
+            }
+            if (n == 2) {
+                flags = ei.changeFlag(flags, FLAG_DIAMOND);
                 setPoints();
             }
         }


### PR DESCRIPTION
## Summary
- Adds a per-element "IEC Diamond Symbol" checkbox to the edit dialog for all four dependent (controlled) source elements: VCVS, VCCS, CCVS, and CCCS
- When enabled, the element body draws as a diamond (rotated square) instead of the default rectangle, matching the IEC standard representation for dependent sources
- Implemented via a `FLAG_DIAMOND` flag in VCCSElm (the common base class), with a `setPoints()` override that replaces the rectangular polygon coordinates with diamond coordinates

## Details
The IEC 60617 standard uses a diamond (rhombus) shape for dependent/controlled sources, distinguishing them visually from independent sources. This option allows users to switch to the standard symbol when desired.

The flag (bit 2) is stored in the element flags field and persisted in both text dump and XML formats. It does not conflict with existing flags (FLAG_SMALL=1, FLAG_SPICE=2 in CCVS/CCCS, FLAG_FLIP_X/Y/XY at bits 10-12).

Addresses sharpie7/circuitjs1#479.

## Test plan
- [ ] Place each dependent source type (VCVS, VCCS, CCVS, CCCS) on the canvas
- [ ] Open edit dialog and verify "IEC Diamond Symbol" checkbox appears
- [ ] Toggle the checkbox on and confirm the element body changes from rectangle to diamond
- [ ] Toggle it off and confirm it reverts to rectangle
- [ ] Save and reload a circuit with diamond-enabled elements; verify the flag persists
- [ ] Test with flipped elements (Flip X/Y) to ensure diamond renders correctly
- [ ] Test with more than 2 inputs to verify diamond scales properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
