### PR TITLE
Fix scope vertical position range at high zoom levels

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/Scope.java
+++ b/src/com/lushprojects/circuitjs1/client/Scope.java
@@ -49,7 +49,7 @@ class ScopePlot {
    // the data we have
     boolean manScaleSet = false; 
     double manScale = 1.0; // Units per division
-    int manVPosition = 0; // 0 is center of screen. +V_POSITION_STEPS/2 is top of screen
+    int manVPosition = 0; // 0 is center of screen. Range is -V_POSITION_STEPS/2 to +V_POSITION_STEPS/2
     double gridMult;
     double plotOffset;
     boolean acCoupled = false;
@@ -217,6 +217,10 @@ class Scope {
     static final int UNITS_COUNT = 4;
     static final double multa[] = {2.0, 2.5, 2.0};
     static final int V_POSITION_STEPS=200;
+    // Multiplier for the position slider range.  The slider can offset the view
+    // by up to V_POSITION_RANGE times the visible half-height in each direction,
+    // allowing users to scroll to signals far from zero even at high zoom levels.
+    static final int V_POSITION_RANGE=10;
     static final double MIN_MAN_SCALE = 1e-9;
     int scopePointCount = 128;
     FFT fft;
@@ -612,8 +616,8 @@ class Scope {
         	    y = (int) (rect.height*(1-ya)*.499);
     	    } else {
     		double gridPx = calc2dGridPx(rect.width, rect.height);
-    		x=(int)(rect.width*.499+(v/plots.get(0).manScale)*gridPx+gridPx*manDivisions*(double)(plots.get(0).manVPosition)/(double)(V_POSITION_STEPS));
-    		y=(int)(rect.height*.499-(yval/plots.get(1).manScale)*gridPx-gridPx*manDivisions*(double)(plots.get(1).manVPosition)/(double)(V_POSITION_STEPS));
+    		x=(int)(rect.width*.499+(v/plots.get(0).manScale)*gridPx+gridPx*manDivisions*V_POSITION_RANGE*(double)(plots.get(0).manVPosition)/(double)(V_POSITION_STEPS));
+    		y=(int)(rect.height*.499-(yval/plots.get(1).manScale)*gridPx-gridPx*manDivisions*V_POSITION_RANGE*(double)(plots.get(1).manVPosition)/(double)(V_POSITION_STEPS));
 
     	    }
     	    drawTo(x, y);
@@ -861,8 +865,8 @@ class Scope {
     	    double xValue;
     	    double yValue;
     	    if (isManualScale()) {
-    		xValue = px.manScale*((double)(app.mouse.mouseCursorX-rect.x-rect.width/2)/gridPx-manDivisions*px.manVPosition/(double)(V_POSITION_STEPS));
-    		yValue = py.manScale*((double)(-app.mouse.mouseCursorY+rect.y+rect.height/2)/gridPx-manDivisions*py.manVPosition/(double)(V_POSITION_STEPS));
+    		xValue = px.manScale*((double)(app.mouse.mouseCursorX-rect.x-rect.width/2)/gridPx-manDivisions*V_POSITION_RANGE*px.manVPosition/(double)(V_POSITION_STEPS));
+    		yValue = py.manScale*((double)(-app.mouse.mouseCursorY+rect.y+rect.height/2)/gridPx-manDivisions*V_POSITION_RANGE*py.manVPosition/(double)(V_POSITION_STEPS));
     	    } else {
     		xValue = ((double)(app.mouse.mouseCursorX-rect.x)/(0.499*(double)(rect.width))-1.0)*scaleX;
     		yValue = -((double)(app.mouse.mouseCursorY-rect.y)/(0.499*(double)(rect.height))-1.0)*scaleY;
@@ -1122,7 +1126,7 @@ class Scope {
     	} else {
     	    gridMid =0;
     	    gridMax = getGridMaxFromManScale(plot);
-    	    positionOffset = gridMax*2.0*(double)(plot.manVPosition)/(double)(V_POSITION_STEPS);
+    	    positionOffset = gridMax*2.0*V_POSITION_RANGE*(double)(plot.manVPosition)/(double)(V_POSITION_STEPS);
     	}
     	plot.plotOffset = -gridMid+positionOffset;
     	


### PR DESCRIPTION
## Summary
- Fixes the scope position slider having too small a range when zoomed in (e.g. 500mV/div), making it impossible to scroll to signals far from zero (e.g. a 5V signal at 500mV/div)
- Introduces a `V_POSITION_RANGE=10` multiplier so the position slider can offset the view by up to 10x the visible half-height in each direction
- All five position-offset formulas (drawPlot, draw2dPlot XY X-axis, draw2dPlot XY Y-axis, cursor readout X, cursor readout Y) are updated consistently

## Details

The bug: when in manual scale mode, the position offset formula was:
```java
positionOffset = gridMax * 2.0 * manVPosition / V_POSITION_STEPS
```
where `gridMax = (manDivisions/2 + 0.05) * manScale`. With the default 8 divisions and `manVPosition` ranging from -100 to +100, the maximum offset was just `gridMax` — roughly the visible area. So at 500mV/div, the slider could only offset by ~2V, making a 5V signal unreachable.

The fix multiplies the offset by `V_POSITION_RANGE=10`:
```java
positionOffset = gridMax * 2.0 * V_POSITION_RANGE * manVPosition / V_POSITION_STEPS
```
This gives 10x the previous range, allowing the slider to reach signals up to ~20V away from zero even at 500mV/div. The same multiplier is applied consistently to the XY plot drawing and cursor readout formulas.

Fixes sharpie7/circuitjs1#1022

## Test plan
- [ ] Open a circuit with a DC voltage source set to 5V
- [ ] Add a scope to the voltage source output
- [ ] Set the scope to manual scale mode and zoom in to 500mV/div
- [ ] Use the position slider — verify it can now scroll to see the 5V signal
- [ ] Check that XY plot mode also correctly offsets with the position slider
- [ ] Check that the cursor readout values in XY mode remain accurate after position adjustment

🤖 Generated with [Claude Code](https://claude.com/claude-code)