### PR TITLE
Fix unrealistic stability for positive-feedback opamp buffer

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/OpAmpElm.java
+++ b/src/com/lushprojects/circuitjs1/client/OpAmpElm.java
@@ -158,6 +158,19 @@ import com.google.gwt.xml.client.Document;
 
 	double lastvd;
 
+	// Initialize lastvd with a tiny offset to break metastable equilibrium.
+	// Without this, a positive-feedback buffer (output wired to non-inverting
+	// input) will unrealistically track the input perfectly because the
+	// Newton-Raphson solver finds the exact metastable solution.  A real
+	// opamp has an input offset voltage (~1 mV) that would immediately push
+	// the output to a supply rail.  This small perturbation mimics that
+	// behavior and is orders of magnitude too small to affect normal
+	// negative-feedback circuits.
+	void reset() {
+	    super.reset();
+	    lastvd = 1e-6;
+	}
+
 	void stamp() {
 	    sim.stampNonLinear(voltSource);
 	    sim.stampMatrix(nodes[2], voltSource, 1);


### PR DESCRIPTION
## Summary
- Adds a tiny initial offset (1e-6 V) to the opamp `lastvd` state in a new `reset()` override, breaking the metastable equilibrium that causes positive-feedback configurations to unrealistically track the input signal
- A reversed-wired opamp buffer (non-inverting input connected to output, inverting input driven by signal) should immediately rail to a supply voltage, but the Newton-Raphson solver was finding the exact metastable solution due to perfectly symmetric initial conditions
- The 1e-6 V perturbation mimics the real-world input offset voltage present in all physical opamps and is orders of magnitude too small to affect normal negative-feedback circuits

Fixes sharpie7/circuitjs1#1009

## Test plan
- [ ] Load a positive-feedback opamp buffer circuit (output wired to non-inverting input, signal on inverting input) and verify the output rails to a supply voltage instead of tracking the input
- [ ] Load a normal negative-feedback opamp buffer and verify it still tracks the input correctly
- [ ] Load existing opamp example circuits (inverting amp, non-inverting amp, etc.) and verify they behave identically
- [ ] Run the Schmitt trigger example (`amp-schmitt.txt`) and verify correct hysteresis behavior

Generated with [Claude Code](https://claude.com/claude-code)