### PR TITLE
Fix 3-phase motor right-side pin label order

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/ThreePhaseMotorElm.java
+++ b/src/com/lushprojects/circuitjs1/client/ThreePhaseMotorElm.java
@@ -87,8 +87,8 @@ class ThreePhaseMotorElm extends CircuitElm {
 	for (i = 0; i != 3; i++) {
 	    interpPoint(point1, point2, posts[i*2], 0, -q*32*(i-1));
 	    interpPoint(point1, point2, leads[i*2], .45, -q*32*(i-1));
-	    interpPoint(point1, point2, posts[i*2+1], 1, q*32*(i-1));
-	    interpPoint(point1, point2, leads[i*2+1], .55, q*32*(i-1));
+	    interpPoint(point1, point2, posts[i*2+1], 1, -q*32*(i-1));
+	    interpPoint(point1, point2, leads[i*2+1], .55, -q*32*(i-1));
 	}
 	motorCenter = interpPoint(point1, point2, .5);
 	allocNodes();


### PR DESCRIPTION
## Summary
- Fix the right-side pin positions on the 3-phase motor element so U2/V2/W2 are on the same row as their left-side counterparts U1/V1/W1, matching IEC standard terminal pairing
- The root cause was opposite sign offsets in `setPoints()`: left-side used `-q*32*(i-1)` while right-side used `+q*32*(i-1)`, reversing the vertical order
- Changed right-side offset to also use `-q*32*(i-1)` so both sides match

**Before (wrong):**
```
U1  W2
V1  V2
W1  U2
```

**After (correct IEC pairing):**
```
U1  U2
V1  V2
W1  W2
```

Fixes sharpie7/circuitjs1#996

## Test plan
- [ ] Place a 3-phase motor element horizontally and verify pin labels read U1-U2, V1-V2, W1-W2 on same rows
- [ ] Place a 3-phase motor element vertically and verify the same correct pairing
- [ ] Connect a 3-phase source and verify the motor still simulates correctly (rotation, current flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)