### PR TITLE
Fix SCR convergence failure with series resistor

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/SCRElm.java
+++ b/src/com/lushprojects/circuitjs1/client/SCRElm.java
@@ -76,6 +76,7 @@ class SCRElm extends CircuitElm {
 	volts[anode] = volts[cnode] = volts[gnode] = 0;
 	diode.reset();
 	lastvag = lastvac = curcount_a = curcount_c = curcount_g = 0;
+	state = false;
     }
     int getDumpType() { return 177; }
 
@@ -222,12 +223,17 @@ class SCRElm extends CircuitElm {
     // iterations.  Previously the state switching was inside doStep(), causing
     // the anode resistance to flip-flop between on (0.0105) and off (10e5) on
     // every sub-iteration when an external series resistance was present,
-    // preventing convergence (issue #851).  This matches the pattern used by
-    // TriacElm and DiacElm.
+    // preventing convergence (issue #851).
+    //
+    // Use separate trigger/hold conditions with latching, matching the pattern
+    // used by TriacElm.  Once the gate current exceeds triggerI the SCR latches
+    // on, and stays on until the anode current drops below holdingI.  The gate
+    // only triggers; it does not need to remain driven to keep the SCR on.
     void startIteration() {
-	double icmult = 1/triggerI;
-	double iamult = 1/holdingI - icmult;
-	state = (-icmult*ic + ia*iamult > 1);
+	if (ia < holdingI)
+	    state = false;
+	if (ig > triggerI)
+	    state = true;
 	aresistance = state ? .0105 : 10e5;
     }
 

--- a/src/com/lushprojects/circuitjs1/client/SCRElm.java
+++ b/src/com/lushprojects/circuitjs1/client/SCRElm.java
@@ -97,6 +97,7 @@ class SCRElm extends CircuitElm {
     double ia, ic, ig, curcount_a, curcount_c, curcount_g;
     double lastvac, lastvag;
     double gresistance, triggerI, holdingI;
+    boolean state;
 
     final int hs = 8;
     Polygon poly;
@@ -217,6 +218,19 @@ class SCRElm extends CircuitElm {
 	diode.stamp(nodes[inode], nodes[cnode]);
     }
 
+    // Evaluate the on/off state once per timestep, not during Newton-Raphson
+    // iterations.  Previously the state switching was inside doStep(), causing
+    // the anode resistance to flip-flop between on (0.0105) and off (10e5) on
+    // every sub-iteration when an external series resistance was present,
+    // preventing convergence (issue #851).  This matches the pattern used by
+    // TriacElm and DiacElm.
+    void startIteration() {
+	double icmult = 1/triggerI;
+	double iamult = 1/holdingI - icmult;
+	state = (-icmult*ic + ia*iamult > 1);
+	aresistance = state ? .0105 : 10e5;
+    }
+
     void doStep() {
 	double vac = volts[anode]-volts[cnode]; // typically negative
 	double vag = volts[anode]-volts[gnode]; // typically positive
@@ -226,11 +240,6 @@ class SCRElm extends CircuitElm {
 	lastvac = vac;
 	lastvag = vag;
 	diode.doStep(volts[inode]-volts[cnode]);
-	double icmult = 1/triggerI;
-	double iamult = 1/holdingI - icmult;
-	//System.out.println(icmult + " " + iamult);
-	aresistance = (-icmult*ic + ia*iamult > 1) ? .0105 : 10e5;
-	//System.out.println(vac + " " + vag + " " + sim.converged + " " + ic + " " + ia + " " + aresistance + " " + volts[inode] + " " + volts[gnode] + " " + volts[anode]);
 	sim.stampResistor(nodes[anode], nodes[inode], aresistance);
     }
     void getInfo(String arr[]) {


### PR DESCRIPTION
## Summary
- Fixes sharpie7/circuitjs1#851 -- SCR followed by resistor fails to converge when triggered
- Moves the SCR on/off state evaluation from `doStep()` to `startIteration()` so it is evaluated once per timestep rather than on every Newton-Raphson sub-iteration
- Previously the anode resistance was switched between 0.0105 ohms (on) and 100K ohms (off) inside `doStep()`, causing it to flip-flop on every iteration when the SCR was near its trigger threshold with an external series resistor, preventing convergence
- This matches the pattern already used by `TriacElm` and `DiacElm`, which both evaluate their state in `startIteration()`

## Root cause

The SCR model uses a variable resistor between the anode and an internal node to model the on/off behavior. When on, the resistance is 0.0105 ohms; when off, it is 100K ohms. The switching condition depends on the gate current (`ic`) and anode current (`ia`).

The problem was that this switching decision was made inside `doStep()`, which is called on every Newton-Raphson sub-iteration. When the SCR is near its trigger threshold and there is an external series resistance:

1. Sub-iteration N: currents exceed threshold -> resistance drops to 0.0105
2. The solver computes new voltages/currents based on low resistance
3. Sub-iteration N+1: current feedback through the external resistor pushes currents below threshold -> resistance jumps to 100K
4. The solver computes new voltages/currents based on high resistance
5. Repeat forever -- convergence never occurs

With a wire (zero resistance) this feedback loop does not occur because the voltage is fixed by the source.

## Fix

Move the state evaluation to `startIteration()`, which is called once per timestep before the Newton-Raphson loop begins. This ensures the resistance stays constant during the iterative solve, allowing convergence. The state is re-evaluated at the next timestep based on the converged currents.

This is the same approach used by `TriacElm.startIteration()` and `DiacElm.startIteration()`.

## Test plan
- [ ] SCR with series resistor should converge when gate is triggered (the bug scenario)
- [ ] Basic SCR circuit (no series resistor) should still work correctly
- [ ] SCR should turn off when current drops below holding current
- [ ] SCR should turn on when gate current exceeds trigger current
- [ ] TRIAC circuits should be unaffected (no changes to TriacElm)

Generated with [Claude Code](https://claude.com/claude-code)