### PR TITLE
remove +/- signs from battery circle symbol

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/VoltageElm.java
+++ b/src/com/lushprojects/circuitjs1/client/VoltageElm.java
@@ -174,21 +174,6 @@ class VoltageElm extends CircuitElm {
 	    drawThickCircle(g, xc, yc, circleSize);
 	    adjustBbox(xc-circleSize, yc-circleSize,
 		       xc+circleSize, yc+circleSize);
-	    // draw + and - signs inside the circle
-	    int signSize = 4;
-	    double plusPos = 0.74;
-	    double minusPos = 0.26;
-	    // + sign: perpendicular bar
-	    interpPoint2(lead1, lead2, ps1, ps2, plusPos, signSize);
-	    drawThickLine(g, ps1, ps2);
-	    // + sign: along-axis bar
-	    double delta = signSize / (circleSize * 2.0);
-	    Point pA = interpPoint(lead1, lead2, plusPos - delta);
-	    Point pB = interpPoint(lead1, lead2, plusPos + delta);
-	    drawThickLine(g, pA, pB);
-	    // - sign: perpendicular bar only
-	    interpPoint2(lead1, lead2, ps1, ps2, minusPos, signSize);
-	    drawThickLine(g, ps1, ps2);
 	} else if (waveform == WF_DC) {
 	    setVoltageColor(g, volts[0]);
 	    setPowerColor(g, false);


### PR DESCRIPTION
Per feedback on #234 — removes the + and - signs drawn inside the battery circle symbol. The circle symbol checkbox remains for users who want it.

Fixes the remaining issue from #234.