### PR TITLE
fix scope charge checkbox toggling

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/Scope.java
+++ b/src/com/lushprojects/circuitjs1/client/Scope.java
@@ -246,7 +246,7 @@ class Scope {
     String text;
     Rectangle rect;
     private boolean manualScale;
-    boolean showI, showV, showScale, showMax, showMin, showP2P, showFreq;
+    boolean showI, showV, showC, showScale, showMax, showMin, showP2P, showFreq;
     boolean plot2d;
     boolean plotXY;
     boolean maxScale;
@@ -336,24 +336,16 @@ class Scope {
     }
 
     void showCharge(boolean b) {
-	if (b) {
+	showC = b;
+	if (b && !hasPlotValue(VAL_CHARGE)) {
 	    // add a charge plot if not already present
-	    if (!hasPlotValue(VAL_CHARGE)) {
-		CircuitElm ce = getElm();
-		if (ce != null) {
-		    int u = ce.getScopeUnits(VAL_CHARGE);
-		    plots.add(new ScopePlot(ce, u, VAL_CHARGE, getManScaleFromMaxScale(u, false)));
-		}
-	    }
-	} else {
-	    // remove any charge plots
-	    for (int i = plots.size() - 1; i >= 0; i--) {
-		if (plots.get(i).value == VAL_CHARGE)
-		    plots.remove(i);
+	    CircuitElm ce = getElm();
+	    if (ce != null) {
+		int u = ce.getScopeUnits(VAL_CHARGE);
+		plots.add(new ScopePlot(ce, u, VAL_CHARGE, getManScaleFromMaxScale(u, false)));
 	    }
 	}
 	calcVisiblePlots();
-	resetGraph();
     }
 
     void showMax    (boolean b) { showMax = b; }
@@ -596,7 +588,7 @@ class Scope {
     	scaleY = .1;
     	speed = 64;
     	showMax = true;
-    	showV = showI = false;
+    	showV = showI = showC = false;
     	showScale = showFreq = manualScale = showMin = showP2P = showElmInfo = false;
     	showFFT = false;
     	plot2d = false;
@@ -609,6 +601,8 @@ class Scope {
     		    showV = true;
     		if (plot.units == UNITS_A)
     		    showI = true;
+    		if (plot.units == UNITS_C)
+    		    showC = true;
     	    }
     	}
     }
@@ -629,6 +623,11 @@ class Scope {
         		if (showI) {
         		    visiblePlots.add(plot);
         		    plot.assignColor(ac++);
+        		}
+        	    } else if (plot.units == UNITS_C) {
+        		if (showC) {
+        		    visiblePlots.add(plot);
+        		    plot.assignColor(oc++);
         		}
         	    } else {
         		visiblePlots.add(plot);
@@ -698,6 +697,14 @@ class Scope {
 		showV = true;
 	    if (u == UNITS_A)
 		showI = true;
+	    if (u == UNITS_C)
+		showC = true;
+	}
+	// re-add charge plot if showC is set and not already present
+	if (showC && ce != null && !hasPlotValue(VAL_CHARGE)) {
+	    int u = ce.getScopeUnits(VAL_CHARGE);
+	    if (u == UNITS_C)
+		plots.add(new ScopePlot(ce, u, VAL_CHARGE, getManScaleFromMaxScale(u, false)));
 	}
 	calcVisiblePlots();
 	resetGraph();
@@ -2138,7 +2145,7 @@ class Scope {
 			(showFFT ? 1024 : 0) | (maxScale ? 8192 : 0) | (showRMS ? 16384 : 0) |
 			(showDutyCycle ? 32768 : 0) | (logSpectrum ? 65536 : 0) |
 			(showAverage ? (1<<17) : 0) | (showElmInfo ? (1<<20) : 0) |
-			(showP2P ? (1<<22) : 0);
+			(showP2P ? (1<<22) : 0) | (showC ? (1<<23) : 0);
 	flags |= FLAG_PLOTS; // 4096
 	int allPlotFlags = 0;
 	for (ScopePlot p : plots) {
@@ -2400,6 +2407,7 @@ class Scope {
     	    triggerMode = TRIGGER_FREERUN;
     	    triggerEdge = TRIGGER_EDGE_RISING;
     	}
+    	showC = (flags & (1<<23)) != 0;
     }
     
     void saveAsDefault() {

--- a/src/com/lushprojects/circuitjs1/client/ScopePropertiesDialog.java
+++ b/src/com/lushprojects/circuitjs1/client/ScopePropertiesDialog.java
@@ -670,7 +670,7 @@ labelledGridManager gridLabels;
 	    resistanceBox.setValue(scope.showingValue(Scope.VAL_R));
 	    resistanceBox.setEnabled(scope.canShowResistance());
 	    if (chargeBox != null)
-		chargeBox.setValue(scope.hasPlotValue(Scope.VAL_CHARGE));
+		chargeBox.setValue(scope.showC);
 	    if (vbeBox != null) {
                 ibBox.setValue(scope.showingValue(Scope.VAL_IB));
                 icBox.setValue(scope.showingValue(Scope.VAL_IC));


### PR DESCRIPTION
## What this fixes (beyond #248)

PR #248 added charge plotting and fixed the initial issue you reported (Show Charge hiding voltage/current). However, the `showCharge()` implementation directly adds/removes plots from the list, unlike `showVoltage()`/`showCurrent()` which use boolean flags (`showV`/`showI`) filtered by `calcVisiblePlots()`. This mismatch causes three remaining bugs:

1. **`setValue()` destroys charge plots.** Toggling scope values (e.g. clicking "Show Resistance") calls `setValue()`, which rebuilds the `plots` vector from scratch. Charge plots are lost because `addValue()` doesn't know to re-add them. With a `showC` flag, `addValue()` can restore the charge plot after a rebuild.

2. **Charge state not persisted on save/load.** `getFlags()`/`setFlags()` don't include charge state, so saving a circuit and reloading it loses the "Show Charge" setting.

3. **No visibility toggle — only add/destroy.** Unchecking "Show Charge" removes the plot entirely and calls `resetGraph()`, destroying accumulated data. Voltage and current instead just toggle visibility via `showV`/`showI` without removing the underlying plot data.

## Fix

Adds a `showC` boolean flag that mirrors the existing `showV`/`showI` pattern:

- `showCharge()` sets `showC` and adds the plot if needed, but no longer removes plots or resets the graph
- `calcVisiblePlots()` filters `UNITS_C` plots by `showC` (like `UNITS_V`/`showV` and `UNITS_A`/`showI`)
- `addValue()` re-adds the charge plot when `showC` is true after a `setValue()` rebuild
- `initialize()` detects existing charge plots and sets `showC`
- `getFlags()`/`setFlags()` persist `showC` using bit 1<<23
- `ScopePropertiesDialog.updateUi()` reads `scope.showC` instead of `scope.hasPlotValue()`

## Steps to reproduce the bugs (on current v3-dev)

1. Place a capacitor with a scope → enable Show Charge → enable Show Resistance → charge plot disappears (bug 1)
2. Place a capacitor with a scope → enable Show Charge → save circuit → reload → charge not shown (bug 2)
3. Place a capacitor with a scope → enable Show Charge → uncheck Show Charge → recheck Show Charge → graph history is gone (bug 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)