### PR TITLE
Fix CrystalElm XML serialization bug and enhance info display

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/CrystalElm.java
+++ b/src/com/lushprojects/circuitjs1/client/CrystalElm.java
@@ -70,7 +70,7 @@ class CrystalElm extends CompositeElm {
         void dumpXml(Document doc, Element elem) {
             super.dumpXml(doc, elem);
             XMLSerializer.dumpAttr(elem, "pc", parallelCapacitance);
-            XMLSerializer.dumpAttr(elem, "sc", parallelCapacitance);
+            XMLSerializer.dumpAttr(elem, "sc", seriesCapacitance);
             XMLSerializer.dumpAttr(elem, "in", inductance);
             XMLSerializer.dumpAttr(elem, "r", resistance);
         }
@@ -137,6 +137,11 @@ class CrystalElm extends CompositeElm {
 		drawDots(g, point2, lead2, -curcount);
 	    }
 	    drawPosts(g);
+	    if (showValues()) {
+		double fs = 1/(Math.sqrt(inductance*seriesCapacitance)*Math.PI*2);
+		String s = getShortUnitText(fs, "Hz");
+		drawValues(g, s, hs);
+	    }
 	}
 	
 	public void stepFinished() {
@@ -147,11 +152,14 @@ class CrystalElm extends CompositeElm {
 	void getInfo(String arr[]) {
 	    arr[0] = "crystal";
 	    getBasicInfo(arr);
-	    arr[3] = "fs = " + getUnitText(1/(Math.sqrt(inductance*seriesCapacitance)*Math.PI*2), "Hz");
-//	    arr[3] = "C = " + getUnitText(capacitance, "F");
-//	    arr[4] = "P = " + getUnitText(getPower(), "W");
-	    //double v = getVoltageDiff();
-	    //arr[4] = "U = " + getUnitText(.5*capacitance*v*v, "J");
+	    double fs = 1/(Math.sqrt(inductance*seriesCapacitance)*Math.PI*2);
+	    double cSer = (parallelCapacitance*seriesCapacitance)/(parallelCapacitance+seriesCapacitance);
+	    double fp = 1/(Math.sqrt(inductance*cSer)*Math.PI*2);
+	    double q = 2*Math.PI*fs*inductance/resistance;
+	    arr[3] = "fs = " + getUnitText(fs, "Hz");
+	    arr[4] = "fp = " + getUnitText(fp, "Hz");
+	    arr[5] = "Q = " + getUnitText(q, "");
+	    arr[6] = "P = " + getUnitText(getPower(), "W");
 	}
 	
 	public boolean canViewInScope() { return true; }


### PR DESCRIPTION
## Summary

- **Fix critical bug** in `dumpXml()` where `seriesCapacitance` was written as `parallelCapacitance` (line 73), silently corrupting crystal parameters when saving in XML format
- **Show parallel resonant frequency** (fp) and **Q factor** in the info panel alongside the existing series frequency (fs)
- **Display series resonant frequency** on the schematic when "Show Values" is enabled, matching the pattern used by CapacitorElm and InductorElm

## The Bug

```java
// BEFORE (line 73): saves parallelCapacitance for BOTH "pc" and "sc" attributes
XMLSerializer.dumpAttr(elem, "pc", parallelCapacitance);
XMLSerializer.dumpAttr(elem, "sc", parallelCapacitance);  // BUG: should be seriesCapacitance

// AFTER: saves the correct value
XMLSerializer.dumpAttr(elem, "sc", seriesCapacitance);
```

Any crystal saved in XML format had its series capacitance replaced with the parallel capacitance value. Loading it back gave the wrong series resonant frequency. The text-based dump format was not affected.

## Enhanced Info Panel

Before: only showed `fs`
After: shows `fs`, `fp`, `Q`, and power — matching the formulas already documented in `crystal.html`

## Test plan

- [ ] Place a crystal element, verify fs/fp/Q display in bottom info panel
- [ ] Save circuit in XML format, reload, verify crystal parameters are preserved correctly
- [ ] Enable "Show Values", verify frequency label appears on crystal symbol
- [ ] Verify existing text-format `.circuitjs.txt` files with crystals still load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)