### PR TITLE
Add junction capacitance (CJE/CJC) to BJT model

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/TransistorElm.java
+++ b/src/com/lushprojects/circuitjs1/client/TransistorElm.java
@@ -82,6 +82,8 @@ class TransistorElm extends CircuitElm implements MouseWheelHandler {
 	void reset() {
 	    volts[0] = volts[1] = volts[2] = 0;
 	    lastvbc = lastvbe = curcount_c = curcount_e = curcount_b = 0;
+	    capVoltBE = capVoltBC = capCurBE = capCurBC = 0;
+	    geqBE = geqBC = ceqBE = ceqBC = 0;
 	    badIters = 0;
 	}
 	public void onMouseWheel(MouseWheelEvent e) {
@@ -134,6 +136,12 @@ class TransistorElm extends CircuitElm implements MouseWheelHandler {
 	}
 
 	double ic, ie, ib, curcount_c, curcount_e, curcount_b;
+
+	// Junction capacitance state (trapezoidal companion model)
+	double capVoltBE, capVoltBC;   // junction voltages from end of previous time step
+	double capCurBE, capCurBC;     // junction cap currents from end of previous time step
+	double geqBE, geqBC;           // companion conductances (computed in startIteration)
+	double ceqBE, ceqBC;           // companion current sources (computed in startIteration)
 	
 	Polygon rectPoly, arrowPoly;
 	Point circleCenter;	
@@ -265,6 +273,45 @@ class TransistorElm extends CircuitElm implements MouseWheelHandler {
 	    }
 	    return(vnew);
 	}
+	// Calculate voltage-dependent junction depletion capacitance.
+	// This is the SPICE standard formula: the PN junction's depletion
+	// layer acts as a parallel-plate capacitor whose plate spacing
+	// changes with applied voltage.
+	//   vj  = voltage across the junction (positive = forward bias)
+	//   cj0 = zero-bias capacitance (the value when no voltage is applied)
+	//   vj0 = built-in junction potential (typically 0.6-0.8V for silicon)
+	//   mj  = grading coefficient (0.33 for linearly graded, 0.5 for abrupt)
+	static double calcJunctionCap(double vj, double cj0, double vj0, double mj) {
+	    if (cj0 <= 0)
+		return 0;
+	    double fc = 0.5;
+	    if (vj < fc * vj0) {
+		// Normal depletion region: C increases as reverse bias decreases
+		return cj0 / Math.pow(1 - vj/vj0, mj);
+	    } else {
+		// Forward bias beyond fc*Vj: linear extrapolation to avoid
+		// the singularity at V=Vj where capacitance would go to infinity
+		return cj0 / Math.pow(1 - fc, 1 + mj) * (1 - fc*(1+mj) + mj*vj/vj0);
+	    }
+	}
+
+	void startIteration() {
+	    // Compute junction capacitance companion model for this time step.
+	    // Uses trapezoidal integration (same as CapacitorElm).
+	    if (model.junctionCapBE > 0 && sim.timeStep > 0) {
+		double vjBE = pnp * capVoltBE;  // physical junction voltage
+		double cje = calcJunctionCap(vjBE, model.junctionCapBE, model.junctionPotBE, model.junctionExpBE);
+		geqBE = 2 * cje / sim.timeStep;
+		ceqBE = -geqBE * capVoltBE - capCurBE;
+	    }
+	    if (model.junctionCapBC > 0 && sim.timeStep > 0) {
+		double vjBC = pnp * capVoltBC;  // physical junction voltage
+		double cjc = calcJunctionCap(vjBC, model.junctionCapBC, model.junctionPotBC, model.junctionExpBC);
+		geqBC = 2 * cjc / sim.timeStep;
+		ceqBC = -geqBC * capVoltBC - capCurBC;
+	    }
+	}
+
 	void stamp() {
 	    sim.stampNonLinear(nodes[0]);
 	    sim.stampNonLinear(nodes[1]);
@@ -421,6 +468,31 @@ class TransistorElm extends CircuitElm implements MouseWheelHandler {
 	    sim.stampRightSide(nodes[1], ceqbc);
 	    sim.stampRightSide(nodes[2], ceqbe);
 
+	    // Junction capacitance companion model stamps.
+	    // Each junction cap is modeled as a conductance (Geq) in parallel
+	    // with a current source (Ceq), using trapezoidal integration.
+	    // This is identical to how CapacitorElm works, but embedded inside
+	    // the transistor and with voltage-dependent capacitance.
+	    if (model.junctionCapBE > 0 && geqBE > 0) {
+		// BE junction cap: conductance between base (node 0) and emitter (node 2)
+		sim.stampMatrix(nodes[0], nodes[0],  geqBE);
+		sim.stampMatrix(nodes[2], nodes[2],  geqBE);
+		sim.stampMatrix(nodes[0], nodes[2], -geqBE);
+		sim.stampMatrix(nodes[2], nodes[0], -geqBE);
+		// Current source (positive = base to emitter)
+		sim.stampRightSide(nodes[0], -ceqBE);
+		sim.stampRightSide(nodes[2],  ceqBE);
+	    }
+	    if (model.junctionCapBC > 0 && geqBC > 0) {
+		// BC junction cap: conductance between base (node 0) and collector (node 1)
+		sim.stampMatrix(nodes[0], nodes[0],  geqBC);
+		sim.stampMatrix(nodes[1], nodes[1],  geqBC);
+		sim.stampMatrix(nodes[0], nodes[1], -geqBC);
+		sim.stampMatrix(nodes[1], nodes[0], -geqBC);
+		// Current source (positive = base to collector)
+		sim.stampRightSide(nodes[0], -ceqBC);
+		sim.stampRightSide(nodes[1],  ceqBC);
+	    }
 	}
 	
 	@Override String getScopeText(int x) {
@@ -454,6 +526,17 @@ class TransistorElm extends CircuitElm implements MouseWheelHandler {
 	    arr[5] = "Vbc = " + getVoltageText(vbc);
 	    arr[6] = "Vce = " + getVoltageText(vce);
 	    arr[7] = "P = " + getUnitText(getPower(), "W");
+	    if (model.junctionCapBE > 0 || model.junctionCapBC > 0) {
+		double cjeVal = calcJunctionCap(vbe*pnp, model.junctionCapBE, model.junctionPotBE, model.junctionExpBE);
+		double cjcVal = calcJunctionCap(vbc*pnp, model.junctionCapBC, model.junctionPotBC, model.junctionExpBC);
+		double cTotal = cjeVal + cjcVal;
+		if (cTotal > 0 && ic != 0) {
+		    // gm = Ic / Vt (transconductance at operating point)
+		    double gm = Math.abs(ic) / vt;
+		    double ft = gm / (2 * Math.PI * cTotal);
+		    arr[8] = "ft = " + getUnitText(ft, "Hz");
+		}
+	    }
 	}
 	
 	double getScopeValue(int x) {
@@ -587,6 +670,18 @@ class TransistorElm extends CircuitElm implements MouseWheelHandler {
 		badIters++;
 	    else
 		badIters = 0;
+
+	    // Save junction cap state for next time step's companion model.
+	    // capVoltXX = node voltage difference across junction (circuit reference, not pnp-adjusted).
+	    // capCurXX  = actual capacitor current at end of this time step.
+	    if (model.junctionCapBE > 0 && geqBE > 0) {
+		capVoltBE = volts[0] - volts[2];
+		capCurBE = geqBE * capVoltBE + ceqBE;
+	    }
+	    if (model.junctionCapBC > 0 && geqBC > 0) {
+		capVoltBC = volts[0] - volts[1];
+		capCurBC = geqBC * capVoltBC + ceqBC;
+	    }
         }
 
 	void flipX(int c2, int count) {

--- a/src/com/lushprojects/circuitjs1/client/TransistorModel.java
+++ b/src/com/lushprojects/circuitjs1/client/TransistorModel.java
@@ -19,6 +19,36 @@ public class TransistorModel implements Editable, Comparable<TransistorModel> {
     double satCur, invRollOffF, BEleakCur, leakBEemissionCoeff, invRollOffR, BCleakCur, leakBCemissionCoeff;
     double emissionCoeffF, emissionCoeffR, invEarlyVoltF, invEarlyVoltR, betaR;
 
+    // Junction capacitance parameters (SPICE Gummel-Poon charge storage)
+    // These model the physical depletion-layer capacitance of each PN junction.
+    // A real transistor junction is a thin insulating depletion region sandwiched
+    // between two conducting regions -- physically identical to a parallel-plate
+    // capacitor whose plate spacing (and therefore capacitance) varies with the
+    // applied voltage.  Reverse bias widens the depletion layer (less capacitance);
+    // forward bias narrows it (more capacitance).
+    //
+    // Without these, the BJT is a pure DC device -- it responds instantly to any
+    // signal, no matter how fast.  With them, the transistor has a finite
+    // transition frequency (ft) and exhibits the propagation delay and phase
+    // shift that real transistors produce.
+    //
+    // SPICE formula:  C(V) = Cj0 / (1 - V/Vj)^Mj   for V < 0.5*Vj
+    //                 (linear extrapolation above 0.5*Vj to avoid singularity)
+    //
+    // Typical values (from SPICE .model cards):
+    //   2N2222A (general-purpose NPN):  CJE=22.01pF VJE=0.7  MJE=0.377
+    //                                   CJC=7.306pF VJC=0.75 MJC=0.3416
+    //   2N3904  (small-signal NPN):     CJE=4.493pF VJE=0.65 MJE=0.2593
+    //                                   CJC=3.638pF VJC=0.75 MJC=0.3085
+    //   2N3906  (small-signal PNP):     CJE=4.49pF  VJE=0.632 MJE=0.267
+    //                                   CJC=4.43pF  VJC=0.632 MJC=0.33
+    double junctionCapBE;                   // CJE: zero-bias BE depletion capacitance (F), 0=disabled
+    double junctionCapBC;                   // CJC: zero-bias BC depletion capacitance (F), 0=disabled
+    double junctionPotBE = 0.75;            // VJE: BE built-in potential (V)
+    double junctionPotBC = 0.75;            // VJC: BC built-in potential (V)
+    double junctionExpBE = 0.33;            // MJE: BE junction grading coefficient
+    double junctionExpBC = 0.33;            // MJC: BC junction grading coefficient
+
     boolean dumped;
     boolean readOnly;
     boolean builtIn;
@@ -31,6 +61,12 @@ public class TransistorModel implements Editable, Comparable<TransistorModel> {
 	leakBEemissionCoeff = 1.5;
 	leakBCemissionCoeff = 2;
 	betaR = 1;
+	junctionCapBE = 0;
+	junctionCapBC = 0;
+	junctionPotBE = 0.75;
+	junctionPotBC = 0.75;
+	junctionExpBE = 0.33;
+	junctionExpBC = 0.33;
 	updateModel();
     }
 
@@ -156,6 +192,12 @@ public class TransistorModel implements Editable, Comparable<TransistorModel> {
 	invEarlyVoltF = copy.invEarlyVoltF;
 	invEarlyVoltR = copy.invEarlyVoltR;
 	betaR = copy.betaR;
+	junctionCapBE = copy.junctionCapBE;
+	junctionPotBE = copy.junctionPotBE;
+	junctionExpBE = copy.junctionExpBE;
+	junctionCapBC = copy.junctionCapBC;
+	junctionPotBC = copy.junctionPotBC;
+	junctionExpBC = copy.junctionExpBC;
 	updateModel();
     }
 
@@ -188,6 +230,17 @@ public class TransistorModel implements Editable, Comparable<TransistorModel> {
 	invEarlyVoltR = Double.parseDouble(st.nextToken());
 	betaR = Double.parseDouble(st.nextToken());
 
+	// Junction capacitance params (optional, for backward compatibility)
+	try {
+	    junctionCapBE = Double.parseDouble(st.nextToken());
+	    junctionPotBE = Double.parseDouble(st.nextToken());
+	    junctionExpBE = Double.parseDouble(st.nextToken());
+	    junctionCapBC = Double.parseDouble(st.nextToken());
+	    junctionPotBC = Double.parseDouble(st.nextToken());
+	    junctionExpBC = Double.parseDouble(st.nextToken());
+	} catch (Exception e) {
+	}
+
 	updateModel();
     }
 
@@ -209,6 +262,12 @@ public class TransistorModel implements Editable, Comparable<TransistorModel> {
 	if (n == 10) return new EditInfo("B-E Leakage Emission Coefficient (NE)", leakBEemissionCoeff);
 	if (n == 11) return new EditInfo("B-C Leakage Saturation Current (ISC)", BCleakCur);
 	if (n == 12) return new EditInfo("B-C Leakage Emission Coefficient (NC)", leakBCemissionCoeff);
+	if (n == 13) return new EditInfo("B-E Zero-Bias Junction Capacitance (CJE)", junctionCapBE);
+	if (n == 14) return new EditInfo("B-E Junction Potential (VJE)", junctionPotBE);
+	if (n == 15) return new EditInfo("B-E Junction Grading Coefficient (MJE)", junctionExpBE);
+	if (n == 16) return new EditInfo("B-C Zero-Bias Junction Capacitance (CJC)", junctionCapBC);
+	if (n == 17) return new EditInfo("B-C Junction Potential (VJC)", junctionPotBC);
+	if (n == 18) return new EditInfo("B-C Junction Grading Coefficient (MJC)", junctionExpBC);
 	return null;
     }
 
@@ -230,6 +289,12 @@ public class TransistorModel implements Editable, Comparable<TransistorModel> {
 	if (n == 10) leakBEemissionCoeff = ei.value;
 	if (n == 11) BCleakCur = ei.value;
 	if (n == 12) leakBCemissionCoeff = ei.value;
+	if (n == 13) junctionCapBE = ei.value;
+	if (n == 14 && ei.value > 0) junctionPotBE = ei.value;
+	if (n == 15 && ei.value > 0) junctionExpBE = ei.value;
+	if (n == 16) junctionCapBC = ei.value;
+	if (n == 17 && ei.value > 0) junctionPotBC = ei.value;
+	if (n == 18 && ei.value > 0) junctionExpBC = ei.value;
 	updateModel();
 	CirSim.theApp.updateModels();
     }
@@ -254,6 +319,16 @@ public class TransistorModel implements Editable, Comparable<TransistorModel> {
 	XMLSerializer.dumpAttr(elem, "vaf", invEarlyVoltF);
 	XMLSerializer.dumpAttr(elem, "var", invEarlyVoltR);
 	XMLSerializer.dumpAttr(elem, "br", betaR);
+	if (junctionCapBE != 0) {
+	    XMLSerializer.dumpAttr(elem, "cje", junctionCapBE);
+	    XMLSerializer.dumpAttr(elem, "vje", junctionPotBE);
+	    XMLSerializer.dumpAttr(elem, "mje", junctionExpBE);
+	}
+	if (junctionCapBC != 0) {
+	    XMLSerializer.dumpAttr(elem, "cjc", junctionCapBC);
+	    XMLSerializer.dumpAttr(elem, "vjc", junctionPotBC);
+	    XMLSerializer.dumpAttr(elem, "mjc", junctionExpBC);
+	}
 	doc.getDocumentElement().appendChild(elem);
     }
 
@@ -278,6 +353,12 @@ public class TransistorModel implements Editable, Comparable<TransistorModel> {
 	invEarlyVoltF = xml.parseDoubleAttr("vaf", invEarlyVoltF);
 	invEarlyVoltR = xml.parseDoubleAttr("var", invEarlyVoltR);
 	betaR = xml.parseDoubleAttr("br", betaR);
+	junctionCapBE = xml.parseDoubleAttr("cje", junctionCapBE);
+	junctionPotBE = xml.parseDoubleAttr("vje", junctionPotBE);
+	junctionExpBE = xml.parseDoubleAttr("mje", junctionExpBE);
+	junctionCapBC = xml.parseDoubleAttr("cjc", junctionCapBC);
+	junctionPotBC = xml.parseDoubleAttr("vjc", junctionPotBC);
+	junctionExpBC = xml.parseDoubleAttr("mjc", junctionExpBC);
 	updateModel();
     }
 }


### PR DESCRIPTION
## Summary

- Adds SPICE Gummel-Poon junction capacitance (depletion-layer charge storage) to the BJT transistor model
- 6 new model parameters: CJE, VJE, MJE (base-emitter) and CJC, VJC, MJC (base-collector)
- Uses trapezoidal companion model -- same integration approach as CapacitorElm and VaractorElm
- Shows transition frequency (ft) in the info panel when junction caps are set
- 100% backward compatible -- all caps default to 0 (disabled), old files load unchanged

## What this enables

Without junction capacitances, the BJT is a pure DC device that responds instantly to any signal. Real transistors have finite switching speed because each PN junction depletion layer acts as a voltage-dependent capacitor that must charge/discharge during transitions.

With CJE/CJC set to real-world values (e.g. 2N2222A: CJE=22pF, CJC=7.3pF), the transistor now exhibits:
- Propagation delay -- output changes lag input changes
- Phase shift -- signals acquire frequency-dependent phase rotation
- Bandwidth limiting -- gain rolls off at high frequencies (ft)
- Ring oscillator startup -- multi-stage oscillators can self-start via the phase delay mechanism

## SPICE junction capacitance formula

C(V) = Cj0 / (1 - V/Vj)^Mj for V < 0.5*Vj (linear extrapolation above to avoid singularity)

Typical values from SPICE .model cards:

| Transistor | CJE | VJE | MJE | CJC | VJC | MJC |
|-----------|------|-----|-----|------|-----|-----|
| 2N2222A | 22.01pF | 0.7V | 0.377 | 7.306pF | 0.75V | 0.3416 |
| 2N3904 | 4.493pF | 0.65V | 0.259 | 3.638pF | 0.75V | 0.309 |
| 2N3906 (PNP) | 4.49pF | 0.632V | 0.267 | 4.43pF | 0.632V | 0.33 |

## Implementation details

- TransistorModel.java: 6 new fields with XML serialization, edit dialog, text dump (backward-compatible try/catch for old format)
- TransistorElm.java: calcJunctionCap() static helper, startIteration() computes companion model per time step, doStep() stamps conductance + current source into MNA matrix, stepFinished() saves state for next step
- Companion model: each junction cap = Norton equivalent (conductance parallel with current source), same pattern as existing CapacitorElm

## Test plan

- [ ] Existing circuits with default model load and simulate unchanged
- [ ] Create custom model with CJE/CJC values, verify ft displays in info panel
- [ ] Common-emitter amplifier with 2N2222A model: verify gain rolls off at high frequency
- [ ] Compare ft readout against hand calculation: ft = gm/(2pi*(Cje+Cjc))
- [ ] Ring oscillator (3-stage) with CJE/CJC: verify oscillation starts up
- [ ] PNP transistor with junction caps: verify correct behavior