### PR TITLE
Add junction capacitance and transit time to diode

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/Diode.java
+++ b/src/com/lushprojects/circuitjs1/client/Diode.java
@@ -29,6 +29,7 @@ class Diode {
 	nodes = new CircuitNode[2];
     }
     void setup(DiodeModel model) {
+	this.model = model;
 	leakage = model.saturationCurrent;
 	zvoltage = model.breakdownVoltage;
 	vscale = model.vscale;
@@ -57,6 +58,7 @@ class Diode {
     
     void reset() {
 	lastvoltdiff = 0;
+	capVolt = capCur = geqCap = ceqCap = 0;
     }
 	
     // Electron thermal voltage at SPICE's default temperature of 27 C (300.15 K):
@@ -79,7 +81,49 @@ class Diode {
     // Critical voltages for limiting the normal diode and Zener breakdown exponentials.
     double vcrit, vzcrit;
     double lastvoltdiff;
+
+    // Junction capacitance state (trapezoidal companion model)
+    double capVolt;     // junction voltage from end of previous time step
+    double capCur;      // junction cap current from end of previous time step
+    double geqCap;      // companion conductance
+    double ceqCap;      // companion current source
+    DiodeModel model;   // reference to model for cap params
     
+    // Calculate voltage-dependent junction depletion capacitance (SPICE formula).
+    static double calcJunctionCap(double vj, double cj0, double vj0, double mj) {
+	if (cj0 <= 0)
+	    return 0;
+	double fc = 0.5;
+	if (vj < fc * vj0) {
+	    return cj0 / Math.pow(1 - vj/vj0, mj);
+	} else {
+	    // linear extrapolation above fc*Vj to avoid singularity
+	    return cj0 / Math.pow(1 - fc, 1 + mj) * (1 - fc*(1+mj) + mj*vj/vj0);
+	}
+    }
+
+    void startIteration(double voltdiff) {
+	if (model == null || sim.timeStep <= 0)
+	    return;
+	if (model.junctionCap > 0 || model.transitTime > 0) {
+	    double cj = calcJunctionCap(voltdiff, model.junctionCap, model.junctionPot, model.junctionExp);
+	    // add diffusion capacitance from transit time: Cd = TT * gd
+	    if (model.transitTime > 0) {
+		double gd = leakage * vdcoef * Math.exp(voltdiff * vdcoef);
+		cj += model.transitTime * gd;
+	    }
+	    geqCap = 2 * cj / sim.timeStep;
+	    ceqCap = -geqCap * capVolt - capCur;
+	}
+    }
+
+    void stepFinished(double voltdiff) {
+	if (model != null && (model.junctionCap > 0 || model.transitTime > 0) && geqCap > 0) {
+	    capVolt = voltdiff;
+	    capCur = geqCap * capVolt + ceqCap;
+	}
+    }
+
     double limitStep(double vnew, double vold) {
 	double arg;
 	double oo = vnew;
@@ -162,6 +206,11 @@ class Diode {
 	    double nc = (eval-1)*leakage - geq*voltdiff;
 	    sim.stampConductance(nodes[0], nodes[1], geq);
 	    sim.stampCurrentSource(nodes[0], nodes[1], nc);
+	    // junction capacitance companion model
+	    if (geqCap > 0) {
+		sim.stampConductance(nodes[0], nodes[1], geqCap);
+		sim.stampCurrentSource(nodes[0], nodes[1], ceqCap);
+	    }
 	} else {
 	    // Zener diode
 	    
@@ -188,6 +237,11 @@ class Diode {
 
 	    sim.stampConductance(nodes[0], nodes[1], geq);
 	    sim.stampCurrentSource(nodes[0], nodes[1],  nc);
+	    // junction capacitance companion model
+	    if (geqCap > 0) {
+		sim.stampConductance(nodes[0], nodes[1], geqCap);
+		sim.stampCurrentSource(nodes[0], nodes[1], ceqCap);
+	    }
 	}
     }
     

--- a/src/com/lushprojects/circuitjs1/client/Diode.java
+++ b/src/com/lushprojects/circuitjs1/client/Diode.java
@@ -246,12 +246,18 @@ class Diode {
     }
     
     double calculateCurrent(double voltdiff) {
+	double current;
 	if (voltdiff >= 0 || zvoltage == 0)
-	    return leakage*(Math.exp(voltdiff*vdcoef)-1);
-	return leakage* (
-	    Math.exp(voltdiff*vdcoef)  
-	    - Math.exp((-voltdiff-zoffset)*vzcoef)  
-	    - 1
-	    );
+	    current = leakage*(Math.exp(voltdiff*vdcoef)-1);
+	else
+	    current = leakage*(
+		Math.exp(voltdiff*vdcoef)
+		- Math.exp((-voltdiff-zoffset)*vzcoef)
+		- 1
+		);
+	// add junction capacitance current from companion model
+	if (geqCap > 0)
+	    current += geqCap * voltdiff + ceqCap;
+	return current;
     }
 }

--- a/src/com/lushprojects/circuitjs1/client/DiodeElm.java
+++ b/src/com/lushprojects/circuitjs1/client/DiodeElm.java
@@ -163,6 +163,9 @@ class DiodeElm extends CircuitElm {
 	drawThickLine(g, cathode[0], cathode[1]);
     }
 	
+    void startIteration() {
+	diode.startIteration(volts[0]-volts[diodeEndNode]);
+    }
     void stamp() {
 	if (hasResistance) {
 	    // create diode from node 0 to internal node
@@ -190,6 +193,16 @@ class DiodeElm extends CircuitElm {
 	arr[3] = "P = " + getUnitText(getPower(), "W");
 	if (model.oldStyle)
 	    arr[4] = "Vf = " + getVoltageText(model.fwdrop);
+	if (model.junctionCap > 0 || model.transitTime > 0) {
+	    double vd = volts[0]-volts[diodeEndNode];
+	    double cj = Diode.calcJunctionCap(vd, model.junctionCap, model.junctionPot, model.junctionExp);
+	    if (model.transitTime > 0) {
+		double gd = model.saturationCurrent * model.vdcoef * Math.exp(vd * model.vdcoef);
+		cj += model.transitTime * gd;
+	    }
+	    int idx = (arr[4] != null) ? 5 : 4;
+	    arr[idx] = "C = " + getUnitText(cj, "F");
+	}
     }
     
     Vector<DiodeModel> models;
@@ -276,6 +289,7 @@ class DiodeElm extends CircuitElm {
         // stop for huge currents that make simulator act weird
         if (Math.abs(current) > 1e12)
             sim.stop("max current exceeded", this);
+	diode.stepFinished(volts[0]-volts[diodeEndNode]);
     }
 
 

--- a/src/com/lushprojects/circuitjs1/client/DiodeModel.java
+++ b/src/com/lushprojects/circuitjs1/client/DiodeModel.java
@@ -311,14 +311,16 @@ public class DiodeModel implements Editable, Comparable<DiodeModel> {
 	}
 	if (n == 4)
 	    return new EditInfo("Breakdown Voltage", breakdownVoltage, -1, -1);
-	if (n == 5)
-	    return new EditInfo("Zero-Bias Junction Capacitance (CJ0)", junctionCap);
-	if (n == 6)
-	    return new EditInfo("Junction Potential (VJ)", junctionPot);
-	if (n == 7)
-	    return new EditInfo("Junction Grading Coefficient (M)", junctionExp);
-	if (n == 8)
-	    return new EditInfo("Transit Time (TT)", transitTime);
+	if (!isSimple()) {
+	    if (n == 5)
+		return new EditInfo("Zero-Bias Junction Capacitance (CJ0)", junctionCap);
+	    if (n == 6)
+		return new EditInfo("Junction Potential (VJ)", junctionPot);
+	    if (n == 7)
+		return new EditInfo("Junction Grading Coefficient (M)", junctionExp);
+	    if (n == 8)
+		return new EditInfo("Transit Time (TT)", transitTime);
+	}
 	return null;
     }
 
@@ -344,10 +346,12 @@ public class DiodeModel implements Editable, Comparable<DiodeModel> {
 	}
 	if (n == 4)
 	    breakdownVoltage = Math.abs(ei.value);
-	if (n == 5) junctionCap = ei.value;
-	if (n == 6 && ei.value > 0) junctionPot = ei.value;
-	if (n == 7 && ei.value > 0) junctionExp = ei.value;
-	if (n == 8 && ei.value >= 0) transitTime = ei.value;
+	if (!isSimple()) {
+	    if (n == 5) junctionCap = ei.value;
+	    if (n == 6 && ei.value > 0) junctionPot = ei.value;
+	    if (n == 7 && ei.value > 0) junctionExp = ei.value;
+	    if (n == 8 && ei.value >= 0) transitTime = ei.value;
+	}
 	updateModel();
 	CirSim.theApp.updateModels();
     }
@@ -407,6 +411,13 @@ public class DiodeModel implements Editable, Comparable<DiodeModel> {
     
     void setSimple(boolean s) {
 	flags = (s) ? FLAGS_SIMPLE : 0;
+	if (s) {
+	    // clear capacitance parameters for simple models
+	    junctionCap = 0;
+	    junctionPot = 0.75;
+	    junctionExp = 0.33;
+	    transitTime = 0;
+	}
     }
     
     void pickName() {

--- a/src/com/lushprojects/circuitjs1/client/DiodeModel.java
+++ b/src/com/lushprojects/circuitjs1/client/DiodeModel.java
@@ -17,7 +17,15 @@ public class DiodeModel implements Editable, Comparable<DiodeModel> {
     int flags;
     String name, description;
     double saturationCurrent, seriesResistance, emissionCoefficient, breakdownVoltage;
-    
+
+    // Junction capacitance parameters (SPICE)
+    // Models the physical depletion-layer capacitance of the PN junction.
+    // C(V) = CJ0 / (1 - V/VJ)^M   for V < 0.5*VJ
+    double junctionCap;                    // CJ0: zero-bias junction capacitance (F), 0=disabled
+    double junctionPot = 0.75;             // VJ: built-in junction potential (V)
+    double junctionExp = 0.33;             // M: junction grading coefficient
+    double transitTime;                    // TT: transit time (s), adds diffusion capacitance Cd = TT*gd
+
     // used for UI code, not guaranteed to be set
     double forwardVoltage, forwardCurrent;
     
@@ -43,8 +51,10 @@ public class DiodeModel implements Editable, Comparable<DiodeModel> {
 	emissionCoefficient = ec;
 	breakdownVoltage = bv;
 	description = d;
-//	CirSim.console("creating diode model " + this);
-//	CirSim.debugger();
+	junctionCap = 0;
+	junctionPot = 0.75;
+	junctionExp = 0.33;
+	transitTime = 0;
 	updateModel();
     }
     
@@ -212,6 +222,10 @@ public class DiodeModel implements Editable, Comparable<DiodeModel> {
 	seriesResistance = 0;
 	emissionCoefficient = 1;
 	breakdownVoltage = 0;
+	junctionCap = 0;
+	junctionPot = 0.75;
+	junctionExp = 0.33;
+	transitTime = 0;
 	updateModel();
     }
     
@@ -222,6 +236,10 @@ public class DiodeModel implements Editable, Comparable<DiodeModel> {
 	emissionCoefficient = copy.emissionCoefficient;
 	breakdownVoltage = copy.breakdownVoltage;
 	forwardCurrent = copy.forwardCurrent;
+	junctionCap = copy.junctionCap;
+	junctionPot = copy.junctionPot;
+	junctionExp = copy.junctionExp;
+	transitTime = copy.transitTime;
 	updateModel();
     }
 
@@ -241,6 +259,13 @@ public class DiodeModel implements Editable, Comparable<DiodeModel> {
 	try {
 	    forwardCurrent = Double.parseDouble(st.nextToken());
 	} catch (Exception e) {}
+	// junction capacitance params (optional, for backward compatibility)
+	try {
+	    junctionCap = Double.parseDouble(st.nextToken());
+	    junctionPot = Double.parseDouble(st.nextToken());
+	    junctionExp = Double.parseDouble(st.nextToken());
+	    transitTime = Double.parseDouble(st.nextToken());
+	} catch (Exception e) {}
 	updateModel();
     }
     
@@ -258,6 +283,10 @@ public class DiodeModel implements Editable, Comparable<DiodeModel> {
 	emissionCoefficient = xml.parseDoubleAttr("n", emissionCoefficient);
 	breakdownVoltage = xml.parseDoubleAttr("bv", breakdownVoltage);
 	forwardCurrent = xml.parseDoubleAttr("fi", forwardCurrent);
+	junctionCap = xml.parseDoubleAttr("cjo", junctionCap);
+	junctionPot = xml.parseDoubleAttr("vj", junctionPot);
+	junctionExp = xml.parseDoubleAttr("m", junctionExp);
+	transitTime = xml.parseDoubleAttr("tt", transitTime);
 	updateModel();
     }
 
@@ -282,6 +311,14 @@ public class DiodeModel implements Editable, Comparable<DiodeModel> {
 	}
 	if (n == 4)
 	    return new EditInfo("Breakdown Voltage", breakdownVoltage, -1, -1);
+	if (n == 5)
+	    return new EditInfo("Zero-Bias Junction Capacitance (CJ0)", junctionCap);
+	if (n == 6)
+	    return new EditInfo("Junction Potential (VJ)", junctionPot);
+	if (n == 7)
+	    return new EditInfo("Junction Grading Coefficient (M)", junctionExp);
+	if (n == 8)
+	    return new EditInfo("Transit Time (TT)", transitTime);
 	return null;
     }
 
@@ -307,6 +344,10 @@ public class DiodeModel implements Editable, Comparable<DiodeModel> {
 	}
 	if (n == 4)
 	    breakdownVoltage = Math.abs(ei.value);
+	if (n == 5) junctionCap = ei.value;
+	if (n == 6 && ei.value > 0) junctionPot = ei.value;
+	if (n == 7 && ei.value > 0) junctionExp = ei.value;
+	if (n == 8 && ei.value >= 0) transitTime = ei.value;
 	updateModel();
 	CirSim.theApp.updateModels();
     }
@@ -333,7 +374,10 @@ public class DiodeModel implements Editable, Comparable<DiodeModel> {
     
     String dump() {
 	dumped = true;
-	return "34 " + CustomLogicModel.escape(name) + " " + flags + " " + saturationCurrent + " " + seriesResistance + " " + emissionCoefficient + " " + breakdownVoltage + " " + forwardCurrent;
+	String s = "34 " + CustomLogicModel.escape(name) + " " + flags + " " + saturationCurrent + " " + seriesResistance + " " + emissionCoefficient + " " + breakdownVoltage + " " + forwardCurrent;
+	if (junctionCap != 0 || transitTime != 0)
+	    s += " " + junctionCap + " " + junctionPot + " " + junctionExp + " " + transitTime;
+	return s;
     }
     
     void dumpXml(Document doc) {
@@ -347,6 +391,13 @@ public class DiodeModel implements Editable, Comparable<DiodeModel> {
         XMLSerializer.dumpAttr(elem, "bv", breakdownVoltage);
 	if (forwardCurrent > 0)
 	    XMLSerializer.dumpAttr(elem, "fi", forwardCurrent);
+	if (junctionCap != 0) {
+	    XMLSerializer.dumpAttr(elem, "cjo", junctionCap);
+	    XMLSerializer.dumpAttr(elem, "vj", junctionPot);
+	    XMLSerializer.dumpAttr(elem, "m", junctionExp);
+	}
+	if (transitTime != 0)
+	    XMLSerializer.dumpAttr(elem, "tt", transitTime);
 	doc.getDocumentElement().appendChild(elem);
     }
 


### PR DESCRIPTION
## Summary
- Adds SPICE junction depletion capacitance (CJ0, VJ, M) and transit time (TT) to the diode model
- Depletion cap uses standard SPICE formula with fc=0.5 linear extrapolation
- Transit time adds diffusion capacitance Cd = TT * gd (small-signal conductance)
- Uses trapezoidal companion model (same pattern as CapacitorElm)

## Technical Details
- **DiodeModel.java**: 4 new parameters (junctionCap, junctionPot, junctionExp, transitTime) with text/XML serialization and edit dialog
- **Diode.java**: `calcJunctionCap()` static method, `startIteration()` computes companion model, `stepFinished()` saves state, `doStep()` stamps companion conductance + current source
- **DiodeElm.java**: Hooks up startIteration/stepFinished calls, shows total capacitance in info panel

## Test plan
- [ ] Create diode with default settings (cap=0), verify behavior unchanged
- [ ] Set CJ0 to a typical value (e.g. 4pF), verify capacitive behavior visible on fast signals
- [ ] Set transit time, verify diffusion capacitance adds at forward bias
- [ ] Verify save/load preserves all parameters
- [ ] Test Zener diode with junction cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)