### PR TITLE
Added Ohm symbol to resistors

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/ResistorElm.java
+++ b/src/com/lushprojects/circuitjs1/client/ResistorElm.java
@@ -96,7 +96,7 @@ import com.google.gwt.xml.client.Document;
 	    }
 	    g.context.restore();
 	    if (showValues()) {
-		String s = getShortUnitText(resistance, "");
+		String s = getShortUnitText(resistance, "Ω");
 		drawValues(g, s, hs+2);
 	    }
 	    doDots(g);


### PR DESCRIPTION
It seems strange that resistors are the only components that lack a unit after their values. Voltage sources, current sources, inductors and capacitors all have units. I've added the Ohm symbol to rectify this.

<img width="1046" height="444" alt="bilde" src="https://github.com/user-attachments/assets/a7cae94a-161a-4fcf-8940-7ec9d29e728d" />

