### PR TITLE
Allow Show Voltage/Current/Power on scope simultaneously (#196)

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/Scope.java
+++ b/src/com/lushprojects/circuitjs1/client/Scope.java
@@ -315,15 +315,35 @@ class Scope {
     
     void showCurrent(boolean b) {
 	showI = b;
-	if (b && !showingVoltageAndMaybeCurrent())
-	    setValue(0);
+	if (b && !hasPlotValue(VAL_CURRENT)) {
+	    CircuitElm ce = getElm();
+	    if (ce != null && plotsAreVICompatible())
+		plots.add(new ScopePlot(ce, UNITS_A, VAL_CURRENT, getManScaleFromMaxScale(UNITS_A, false)));
+	    else if (!showingVoltageAndMaybeCurrent())
+		setValue(0);
+	}
 	calcVisiblePlots();
     }
     void showVoltage(boolean b) {
 	showV = b;
-	if (b && !showingVoltageAndMaybeCurrent())
-	    setValue(0);
+	if (b && !hasPlotValue(VAL_VOLTAGE)) {
+	    CircuitElm ce = getElm();
+	    if (ce != null && plotsAreVICompatible())
+		plots.add(new ScopePlot(ce, UNITS_V, VAL_VOLTAGE, getManScaleFromMaxScale(UNITS_V, false)));
+	    else if (!showingVoltageAndMaybeCurrent())
+		setValue(0);
+	}
 	calcVisiblePlots();
+    }
+
+    // True if all plots are V/I/Power/Charge — adding another V or I plot is safe (no wipe needed)
+    boolean plotsAreVICompatible() {
+	for (int i = 0; i != plots.size(); i++) {
+	    int v = plots.get(i).value;
+	    if (v != VAL_VOLTAGE && v != VAL_CURRENT && v != VAL_POWER && v != VAL_CHARGE)
+		return false;
+	}
+	return true;
     }
 
     // check if any plot has the given value (unlike showingValue which checks ALL plots)
@@ -349,6 +369,25 @@ class Scope {
 	    // remove any charge plots
 	    for (int i = plots.size() - 1; i >= 0; i--) {
 		if (plots.get(i).value == VAL_CHARGE)
+		    plots.remove(i);
+	    }
+	}
+	calcVisiblePlots();
+	resetGraph();
+    }
+
+    void showPower(boolean b) {
+	if (b) {
+	    // add a power plot if not already present
+	    if (!hasPlotValue(VAL_POWER)) {
+		CircuitElm ce = getElm();
+		if (ce != null)
+		    plots.add(new ScopePlot(ce, UNITS_W, VAL_POWER, getManScaleFromMaxScale(UNITS_W, false)));
+	    }
+	} else {
+	    // remove any power plots
+	    for (int i = plots.size() - 1; i >= 0; i--) {
+		if (plots.get(i).value == VAL_POWER)
 		    plots.remove(i);
 	    }
 	}
@@ -2473,7 +2512,7 @@ class Scope {
     	if (mi == "showelminfo")
 	    	showElmInfo = state;
     	if (mi == "showpower")
-    		setValue(VAL_POWER);
+    		showPower(state);
     	if (mi == "showib")
     		setValue(VAL_IB);
     	if (mi == "showic")

--- a/src/com/lushprojects/circuitjs1/client/ScopePropertiesDialog.java
+++ b/src/com/lushprojects/circuitjs1/client/ScopePropertiesDialog.java
@@ -649,9 +649,9 @@ labelledGridManager gridLabels;
 	    hScaleGrid.getRowFormatter().setVisible(1, hScaleLabel.expanded);
 	    speedBar.setValue(10-(int)Math.round(Math.log(scope.speed)/Math.log(2)));
 	    if (voltageBox != null) {
-		voltageBox.setValue(scope.showV && !scope.showingValue(Scope.VAL_POWER));
-		currentBox.setValue(scope.showI && !scope.showingValue(Scope.VAL_POWER));
-		powerBox.setValue(scope.showingValue(Scope.VAL_POWER));
+		voltageBox.setValue(scope.showV);
+		currentBox.setValue(scope.showI);
+		powerBox.setValue(scope.hasPlotValue(Scope.VAL_POWER));
 	    }
 	    scaleBox.setValue(scope.showScale);
 	    peakBox.setValue(scope.showMax);

--- a/src/com/lushprojects/circuitjs1/client/ScopePropertiesDialog.java
+++ b/src/com/lushprojects/circuitjs1/client/ScopePropertiesDialog.java
@@ -649,8 +649,8 @@ labelledGridManager gridLabels;
 	    hScaleGrid.getRowFormatter().setVisible(1, hScaleLabel.expanded);
 	    speedBar.setValue(10-(int)Math.round(Math.log(scope.speed)/Math.log(2)));
 	    if (voltageBox != null) {
-		voltageBox.setValue(scope.showV);
-		currentBox.setValue(scope.showI);
+		voltageBox.setValue(scope.hasPlotValue(Scope.VAL_VOLTAGE));
+		currentBox.setValue(scope.hasPlotValue(Scope.VAL_CURRENT));
 		powerBox.setValue(scope.hasPlotValue(Scope.VAL_POWER));
 	    }
 	    scaleBox.setValue(scope.showScale);


### PR DESCRIPTION
## Summary

Fixes #196.

@pfalstad — per your comment on #196: *"I think they want both at once. Right now they are mutually exclusive, but they don't really need to be."* This makes Show Voltage / Show Current / Show Power Consumed independent toggles on the scope, so all three can be displayed at once.

## Changes

- **`Scope.java`**: new `showPower(boolean)` modeled on the existing `showCharge(boolean)` — adds or removes a `UNITS_W` `ScopePlot` rather than wiping all plots. `handleMenu("showpower")` calls `showPower(state)` instead of `setValue(VAL_POWER)`.
- **`Scope.java`**: `showVoltage`/`showCurrent` now add a missing V/I plot in-place when the scope contains only V/I/Power/Charge plots, so toggling V/I on a power-only scope no longer wipes the power plot. Transistor and resistance modes still reset via `setValue(0)` as before.
- **`ScopePropertiesDialog.java`**: each of the three checkboxes reflects its own state (`showV`, `showI`, `hasPlotValue(VAL_POWER)`) — no more `&& !showingValue(VAL_POWER)` cross-coupling.

Backward compatible: a saved scope with a single `VAL_POWER` plot still loads and displays power (UNITS_W plots are always visible in `calcVisiblePlots`).

## Test plan

- [ ] Right-click scope → Properties → tick all three of Show Voltage, Show Current, Show Power Consumed: all three traces render.
- [ ] Untick Show Power: V and I remain.
- [ ] Start with power-only scope, tick Show Voltage: power persists, V is added.
- [ ] Load an old circuit that saved a power-only scope: still shows power.
- [ ] Transistor scope (Show Vbe/Vce/Ic/etc.) behavior unchanged.
- [ ] R-L compensation example from the issue: voltage, current, and instantaneous power all visible together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)