### PR TITLE
Average the wattmeter over whole cycles

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/WattmeterElm.java
+++ b/src/com/lushprojects/circuitjs1/client/WattmeterElm.java
@@ -30,10 +30,9 @@ class WattmeterElm extends CircuitElm {
     int meter; // 0=instantaneous, 1=average
     final int PM_INST = 0;
     final int PM_AVG = 1;
-    double avgPower, totalPower, count;
-    int zerocount;
-    double maxP, lastMaxP, minP, lastMinP;
-    boolean increasingP = true, decreasingP = true;
+    double avgPower, totalEnergy, cycleTime, lastCycleTime;
+    double runEnergy, runTime, zeroTime, peak, trough;
+    boolean wasAboveMid, haveFullCycle;
 
     public WattmeterElm(int xx, int yy) {
 	super(xx, yy);
@@ -147,50 +146,71 @@ class WattmeterElm extends CircuitElm {
 
     void stepFinished() {
 	double p = getPower();
-	count++;
-	totalPower += p;
-	if (p > maxP && increasingP) {
-	    maxP = p;
-	    increasingP = true;
-	    decreasingP = false;
-	}
-	if (p < maxP && increasingP) {
-	    lastMaxP = maxP;
-	    minP = p;
-	    increasingP = false;
-	    decreasingP = true;
-	    avgPower = totalPower / count;
+	double dt = sim.timeStep;
+	cycleTime += dt;
+	totalEnergy += p * dt;
+	runTime += dt;
+	runEnergy += p * dt;
+
+	// Average over whole cycles, delimited by rising crossings of the long-run mean.
+	// The previous code delimited them by the local extremes of the power waveform,
+	// which is half a period for a sine wave, and for a waveform with a flat section -
+	// such as the output of a half-wave rectifier - gives a window that falls either
+	// side of the conducting part instead of spanning a period.
+	double mid = runEnergy / runTime;
+
+	// Compare against the threshold with hysteresis. While the power is constant it
+	// equals its own running mean, and a bare p > mid then chatters on rounding noise
+	// alone, manufacturing crossings a fraction of a timestep apart. Those leave a
+	// period estimate orders of magnitude too short behind, which the timeout and the
+	// zero check below would then act on.
+	if (p > peak)
+	    peak = p;
+	if (p < trough)
+	    trough = p;
+	double band = (peak - trough) * .05 + Math.abs(peak) * 1e-9;
+	boolean above = wasAboveMid ? p > mid - band : p > mid + band;
+
+	if (above && !wasAboveMid) {
+	    if (haveFullCycle) {
+		avgPower = totalEnergy / cycleTime;
+		if (Double.isNaN(avgPower))
+		    avgPower = 0;
+		lastCycleTime = cycleTime;
+	    } else {
+		// The run up to the first crossing is a partial cycle. Measuring it would
+		// leave a period estimate far shorter than the real one.
+		haveFullCycle = true;
+	    }
+	    totalEnergy = 0;
+	    cycleTime = 0;
+	} else if (lastCycleTime > 0 && cycleTime > lastCycleTime * 8) {
+	    // the waveform stopped or changed shape; don't freeze on a stale reading
+	    avgPower = totalEnergy / cycleTime;
 	    if (Double.isNaN(avgPower))
 		avgPower = 0;
-	    count = 0;
-	    totalPower = 0;
+	    totalEnergy = 0;
+	    cycleTime = 0;
 	}
-	if (p < minP && decreasingP) {
-	    minP = p;
-	    increasingP = false;
-	    decreasingP = true;
-	}
-	if (p > minP && decreasingP) {
-	    lastMinP = minP;
-	    maxP = p;
-	    increasingP = true;
-	    decreasingP = false;
-	    avgPower = totalPower / count;
-	    if (Double.isNaN(avgPower))
-		avgPower = 0;
-	    count = 0;
-	    totalPower = 0;
-	}
+	wasAboveMid = above;
+
+	// Constant power never crosses its own mean, so no period is ever measured. Report
+	// the running mean until one is, which is the right answer for DC anyway.
+	if (lastCycleTime == 0)
+	    avgPower = mid;
+
+	// Clear the reading once the power has been off for longer than a period. The
+	// previous code cleared after five zero samples, which a rectified waveform reaches
+	// during every cycle; tying it to the measured period does not.
 	if (p == 0) {
-	    zerocount++;
-	    if (zerocount > 5) {
-		totalPower = 0;
+	    zeroTime += dt;
+	    if (lastCycleTime > 0 && zeroTime > lastCycleTime * 1.5) {
 		avgPower = 0;
-		maxP = 0;
-		minP = 0;
+		totalEnergy = 0;
+		cycleTime = 0;
 	    }
 	} else {
-	    zerocount = 0;
+	    zeroTime = 0;
 	}
     }
 


### PR DESCRIPTION
Fixes #377.

## The problem

The average power reading delimits its averaging window with the local extremes of the power
waveform: it accumulates until `p` turns from rising to falling, or the other way round, and
divides at each turning point.

For a sine that window is half a period, which happens to give the right mean. For a waveform
with a flat section it does not. With a half-wave rectifier, the window ends up either side of
the conducting part rather than spanning a period, so the reading alternates between the mean
of the conducting half and zero — the 60 W / 0 W in the issue, where 30 W is expected.

Two more cases are wrong for the same reason and are not in the issue: a DC load reads 0 W
instead of its actual power, because constant power has no turning points at all; and a square
wave alternates between 0 W and its peak.

## The change

Delimit the window with rising crossings of the long-run mean instead. That is the same idea
the scope already uses in `ScopeOverlays.iterateCycles()`, which is why the scope reads these
circuits correctly today. `p * dt` is integrated rather than `p` summed, since `timeStep` is
adaptive.

Three details are needed to make it hold up, each of which I got wrong before measuring:

- **Hysteresis on the comparison.** Constant power equals its own running mean, so a bare
  `p > mid` chatters on rounding noise and manufactures crossings a fraction of a timestep
  apart. Those leave a period estimate orders of magnitude too short behind, which the timeout
  and the zero check then act on.
- **Discard the run up to the first crossing.** It is a partial cycle, and measuring it leaves
  the same too-short period estimate.
- **Clear on a period, not on five samples.** The old rule cleared the reading after five
  consecutive zero samples, which a rectified waveform reaches during every cycle. Tying it to
  the measured period keeps the intent (a stopped circuit reads zero) without firing mid-cycle.

The reading for a constant load falls back to the running mean, since constant power never
crosses it and no period is ever measured.

## Measurements

Against the analytic values, 120 W peak at 40 Hz, sampled after ten periods:

| waveform | expected | before | after |
| --- | --- | --- | --- |
| full wave | 60 W | 59.86 .. 60.14 | 60.00 |
| half wave | 30 W | 0.00 .. 60.10 | 30.00 |
| DC | 120 W | 0.00 | 120.00 |
| square wave, 50% duty | 60 W | 0.00 .. 119.95 | 60.00 |
| square wave, 25% duty | 30 W | 0.00 .. 119.90 | 30.00 |
| switched off | 0 W | 0.00 | 0.00 |

Repeated with a ten times coarser timestep, the new figures are unchanged to within 0.01 W.

I checked these by running the old and new `stepFinished()` side by side against synthetic
power waveforms with known means, rather than in the app, since `TestManager` is currently
commented out and there is no harness to hang a regression test on. Happy to fold the cases
into one if you would like it wired back up.
